### PR TITLE
Add some error reporting when we start evmserverd

### DIFF
--- a/lib/gems/pending/appliance_console/database_configuration.rb
+++ b/lib/gems/pending/appliance_console/database_configuration.rb
@@ -221,7 +221,14 @@ FRIENDLY
     end
 
     def start_evm
-      pid = fork { LinuxAdmin::Service.new("evmserverd").enable.start }
+      pid = fork do
+        begin
+          LinuxAdmin::Service.new("evmserverd").enable.start
+        rescue => e
+          logger.error("Failed to enable and start evmserverd service: #{e.message}")
+          logger.error(e.backtrace.join("\n"))
+        end
+      end
       Process.detach(pid)
     end
 


### PR DESCRIPTION
This will hopefully help pin down #10300

Because we fork to run the systemd commands, it may be that some errors are not getting reported anywhere. This change will make sure we can see any errors in the `appliance_console.log`

@jvlcek please review

Was: https://github.com/ManageIQ/manageiq/pull/12202