### PR TITLE
Add pathname require where needed

### DIFF
--- a/lib/manageiq/gems/pending.rb
+++ b/lib/manageiq/gems/pending.rb
@@ -1,3 +1,5 @@
+require 'pathname'
+
 module ManageIQ
   module Gems
     module Pending


### PR DESCRIPTION
Attempting to run specs caused the following error:

```
09:11:45:~/Source/manageiq-gems-pending (move_some_ha_config_to_base_class)$ rake
/home/ncarboni/Source/manageiq-gems-pending/lib/manageiq/gems/pending.rb:5:in `root': uninitialized constant ManageIQ::Gems::Pending::Pathname (NameError)
	from /home/ncarboni/Source/manageiq-gems-pending/lib/manageiq/gems/pending.rb:11:in `<top (required)>'
	from /home/ncarboni/Source/manageiq-gems-pending/spec/spec_helper.rb:1:in `require_relative'
	from /home/ncarboni/Source/manageiq-gems-pending/spec/spec_helper.rb:1:in `<top (required)>'
	from /home/ncarboni/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/ncarboni/.rubies/ruby-2.3.1/lib/ruby/2.3.0/rubygems/core_ext/kernel_require.rb:55:in `require'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `block in requires='
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `each'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration.rb:1394:in `requires='
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:112:in `block in process_options_into'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:111:in `each'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:111:in `process_options_into'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/configuration_options.rb:21:in `configure'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:99:in `setup'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:86:in `run'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:71:in `run'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/lib/rspec/core/runner.rb:45:in `invoke'
	from /home/ncarboni/.gem/ruby/2.3.1/gems/rspec-core-3.5.4/exe/rspec:4:in `<main>'
```

This should fix that.