### PR TITLE
Use version 0.14.0 of the 'ovirt' gem

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-sftp",                "~>2.1.2"
   s.add_runtime_dependency "nokogiri",                "~>1.6.8"
   s.add_runtime_dependency "openscap",                "~>0.4.3"
-  s.add_runtime_dependency "ovirt",                   "~>0.13.0"
+  s.add_runtime_dependency "ovirt",                   "~>0.14.0"
   s.add_runtime_dependency "parallel",                "~>1.9" # For OvirtInventory
   s.add_runtime_dependency "pg",                      "~>0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~>0.1.0"


### PR DESCRIPTION
This patch changes the Gemfile so that it uses version 0.14.0 of the
'ovirt' gem, as this is needed in order to fix several issues with hot
pulgging of memory in oVirt.

Note that this depends on ManageIQ/ovirt/pull/72, as that is the pull
that makes the required changes to the `ovirt` gem and bumps the
version number to `0.14.0`.