### PR TITLE
Add memoryReservationLockedToMax from vSphere 5.0

### DIFF
--- a/lib/gems/pending/VMwareWebService/wsdl41/methods/VirtualMachineConfigInfo.yml
+++ b/lib/gems/pending/VMwareWebService/wsdl41/methods/VirtualMachineConfigInfo.yml
@@ -98,3 +98,5 @@ vAssertsEnabled:
   :type: :SOAP::SOAPBoolean
 changeTrackingEnabled:
   :type: :SOAP::SOAPBoolean
+memoryReservationLockedToMax:
+  :type: :SOAP::SOAPBoolean

--- a/lib/gems/pending/VMwareWebService/wsdl41/methods/VirtualMachineConfigSpec.yml
+++ b/lib/gems/pending/VMwareWebService/wsdl41/methods/VirtualMachineConfigSpec.yml
@@ -99,3 +99,5 @@ changeTrackingEnabled:
 vmProfile:
   :type: :VirtualMachineProfileSpec
   :isArray: true
+memoryReservationLockedToMax:
+  :type: :SOAP::SOAPBoolean

--- a/lib/gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
+++ b/lib/gems/pending/VMwareWebService/wsdl41/vimws25MappingRegistry.rb
@@ -34510,7 +34510,10 @@
       ["ftInfo", "VimWs25::FaultToleranceConfigInfo", [0, 1]],
       ["vAppConfig", "VimWs25::VmConfigInfo", [0, 1]],
       ["vAssertsEnabled", "SOAP::SOAPBoolean", [0, 1]],
-      ["changeTrackingEnabled", "SOAP::SOAPBoolean", [0, 1]]
+      ["changeTrackingEnabled", "SOAP::SOAPBoolean", [0, 1]],
+
+      # memoryReservationLockedToMax added from VIM 5.0
+      ["memoryReservationLockedToMax", "SOAP::SOAPBoolean", [0, 1]]
     ]
   )
 
@@ -34629,7 +34632,10 @@
       ["changeTrackingEnabled", "SOAP::SOAPBoolean", [0, 1]],
 
       # vmProfile added from VIM 5.5
-      ["vmProfile", "VimWs25::VirtualMachineProfileSpec[]", [0, nil]]
+      ["vmProfile", "VimWs25::VirtualMachineProfileSpec[]", [0, nil]],
+
+      # memoryReservationLockedToMax added from VIM 5.0
+      ["memoryReservationLockedToMax", "SOAP::SOAPBoolean", [0, 1]]
     ]
   )
 
@@ -77249,7 +77255,10 @@
       ["ftInfo", "VimWs25::FaultToleranceConfigInfo", [0, 1]],
       ["vAppConfig", "VimWs25::VmConfigInfo", [0, 1]],
       ["vAssertsEnabled", "SOAP::SOAPBoolean", [0, 1]],
-      ["changeTrackingEnabled", "SOAP::SOAPBoolean", [0, 1]]
+      ["changeTrackingEnabled", "SOAP::SOAPBoolean", [0, 1]],
+
+      # memoryReservationLockedToMax added from VIM 5.0
+      ["memoryReservationLockedToMax", "SOAP::SOAPBoolean", [0, 1]]
     ]
   )
 
@@ -77376,7 +77385,10 @@
       ["changeTrackingEnabled", "SOAP::SOAPBoolean", [0, 1]],
 
       # vmProfile added from VIM 5.5
-      ["vmProfile", "VimWs25::VirtualMachineProfileSpec[]", [0, nil]]
+      ["vmProfile", "VimWs25::VirtualMachineProfileSpec[]", [0, nil]],
+
+      # memoryReservationLockedToMax added from VIM 5.0
+      ["memoryReservationLockedToMax", "SOAP::SOAPBoolean", [0, 1]]
     ]
   )
 


### PR DESCRIPTION
This is the `VMwareWebService` part of PR https://github.com/ManageIQ/manageiq/pull/12450
This adds the option `memoryReservationLockedToMax` to `VirtualMachineConfigSpec` so that it can be explicitly disabled in provisioning.

https://bugzilla.redhat.com/show_bug.cgi?id=1384122