### PR TITLE
Use KEY_ROOT over RAILS_ROOT for the certs

### DIFF
--- a/lib/gems/pending/appliance_console/key_configuration.rb
+++ b/lib/gems/pending/appliance_console/key_configuration.rb
@@ -5,7 +5,7 @@ require 'active_support/all'
 require 'util/miq-password'
 
 module ApplianceConsole
-  CERT_DIR = ENV['KEY_ROOT']
+  CERT_DIR = ENV['KEY_ROOT'] || RAILS_ROOT.join("certs")
   KEY_FILE = "#{CERT_DIR}/v2_key"
 
   class KeyConfiguration

--- a/lib/gems/pending/appliance_console/key_configuration.rb
+++ b/lib/gems/pending/appliance_console/key_configuration.rb
@@ -2,12 +2,10 @@ require 'pathname'
 require 'fileutils'
 require 'net/scp'
 require 'active_support/all'
-
-RAILS_ROOT ||= Pathname.new(__dir__).join("../../..")
 require 'util/miq-password'
 
 module ApplianceConsole
-  CERT_DIR = "#{RAILS_ROOT}/certs"
+  CERT_DIR = ENV['KEY_ROOT']
   KEY_FILE = "#{CERT_DIR}/v2_key"
 
   class KeyConfiguration


### PR DESCRIPTION
This is defined in our environment, is more applicable, and should be more reliable than RAILS_ROOT.

Currently this is failing because rails root isn't defined and the file is no longer in the manageiq code tree.
This means that `Pathname.new(__dir__).join("../../..")` is no longer valid.

@Fryguy please review.