### PR TITLE
Bump Kubeclient version to 2.2.0

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "httpclient",              "~>2.7.1"
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"
   s.add_runtime_dependency "iniparse"
-  s.add_runtime_dependency "kubeclient",              "=2.1.0"
+  s.add_runtime_dependency "kubeclient",              "=2.2.0"
   s.add_runtime_dependency "linux_admin",             "~>0.19.0"
   s.add_runtime_dependency "linux_block_device",      "~>0.2.1"
   s.add_runtime_dependency "log4r",                   "=1.1.8"


### PR DESCRIPTION
The new Kubeclient version introduces a fix (https://github.com/abonas/kubeclient/pull/209) for undefined 'rindex' method called during discovery.
BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1387614