### PR TITLE
Removed extra prompt in appliance menu

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -33,7 +33,7 @@ I18n.enforce_available_locales = true
 I18n.backend.load_translations
 
 $terminal.wrap_at = 80
-$terminal.page_at = 25
+$terminal.page_at = 35
 
 def summary_entry(field, value)
   dfield = "#{field}:"


### PR DESCRIPTION
Removed extra prompt in console menu : ```-- press enter/return to continue or q to stop--```.  

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1394054

There is new menu item was added to main appliance menu. This cause number of menu items reached limit after which pagination  of menu will start. 

**FIX:** increase setting for pagination

@miq-bot add-label bug

\cc @gtanzillo 