### PR TITLE
Remove forced GC.start from every API call

### DIFF
--- a/lib/gems/pending/VMwareWebService/VimService.rb
+++ b/lib/gems/pending/VMwareWebService/VimService.rb
@@ -1254,11 +1254,11 @@ class VimService < Handsoap::Service
   end
 
   def handle_memory_and_gc(response)
+    xml_len = response.instance_variable_get(:@http_body).length
+
     # At this point we don't need the internal raw XML content since we
     #   have the parsed XML document, so we can free it for the GC.
     response.instance_variable_set(:@http_body, nil)
-
-    xml_len = response.document.to_s.length
 
     @xml_payload_lock.synchronize do
       @xml_payload_len += xml_len

--- a/lib/gems/pending/VMwareWebService/VimService.rb
+++ b/lib/gems/pending/VMwareWebService/VimService.rb
@@ -14,6 +14,10 @@ class VimService < Handsoap::Service
     @serviceInstanceMor = VimString.new("ServiceInstance", "ServiceInstance")
     @session_cookie     = nil
 
+    @xml_payload_len  = 0
+    @xml_payload_max  = 10.megabytes
+    @xml_payload_lock = Mutex.new
+
     @sic = retrieveServiceContent
 
     @about           = @sic.about
@@ -1249,16 +1253,32 @@ class VimService < Handsoap::Service
     end
   end
 
+  def handle_memory_and_gc(response)
+    # At this point we don't need the internal raw XML content since we
+    #   have the parsed XML document, so we can free it for the GC.
+    response.instance_variable_set(:@http_body, nil)
+
+    xml_len = response.document.to_s.length
+
+    @xml_payload_lock.synchronize do
+      @xml_payload_len += xml_len
+
+      if @xml_payload_len > @xml_payload_max
+        @xml_payload_len = 0
+
+        # Force a GC, because Ruby's GC is triggered on number of objects without
+        #   regard to size.  The object we just freed may not be released right away.
+        GC.start
+      end
+    end
+  end
+
   def parse_response(response, rType)
     doc  = response.document
     raise "Response <#{response.inspect}> has no XML document" if doc.nil?
 
-    # At this point we don't need the internal raw XML content since we
-    #   have the parsed XML document, so we can free it for the GC.
-    response.instance_variable_set(:@http_body, nil)
-    # Force a GC, because Ruby's GC is triggered on number of objects without
-    #   regard to size.  The object we just freed may not be released right away.
-    GC.start
+    # Cleanup the raw XML document from the response and kick a GC
+    handle_memory_and_gc(response)
 
     search_path = "//n1:#{rType}"
     node = doc.xpath(search_path, @ns).first


### PR DESCRIPTION
Average timings for `collect_inventory_for_targets` over 5 runs:
`With GC.start: 62.57s`
`Without GC.start: 38.06s`


So 38% less time to collect inventory.

The steady state memory usage (after the first full refresh completes) was:
`With GC.start: 549MB`
`Without GC.start: 632MB`

So an increase of 15% memory usage.

https://bugzilla.redhat.com/show_bug.cgi?id=1378998
https://bugzilla.redhat.com/show_bug.cgi?id=1341402
https://bugzilla.redhat.com/show_bug.cgi?id=1353707