### PR TITLE
Added exception clases for router add/remove interfaces

### DIFF
--- a/lib/gems/pending/util/miq-exception.rb
+++ b/lib/gems/pending/util/miq-exception.rb
@@ -124,6 +124,8 @@ module MiqException
   class MiqNetworkRouterCreateError < Error; end
   class MiqNetworkRouterUpdateError < Error; end
   class MiqNetworkRouterDeleteError < Error; end
+  class MiqNetworkRouterAddInterfaceError < Error; end
+  class MiqNetworkRouterRemoveInterfaceError < Error; end
 
   class MiqVolumeValidationError < Error; end
   class MiqVolumeCreateError < Error; end


### PR DESCRIPTION
This adds the exception classes needed by the add/remove interface API calls on NetworkRouter

https://bugzilla.redhat.com/show_bug.cgi?id=1394284