### PR TITLE
VixDiskLib Fixes Required by Creation of manageiq-gems-pending Gem

### DIFF
--- a/lib/gems/pending/VMwareWebService/MiqVimVdlMod.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimVdlMod.rb
@@ -4,7 +4,7 @@ module MiqVimVdlConnectionMod
   # Return a VixDiskLib connection object for the same server that VIM is connected to.
   #
   def vdlConnection
-    require 'VixDiskLib'
+    require 'VixDiskLib/VixDiskLib'
     VixDiskLib.init(->(s) { $vim_log.info  "VMware(VixDiskLib): #{s}" },
                     ->(s) { $vim_log.warn  "VMware(VixDiskLib): #{s}" },
                     ->(s) { $vim_log.error "VMware(VixDiskLib): #{s}" })
@@ -29,7 +29,7 @@ module MiqVimVdlVcConnectionMod
   # has finished accessing the VM's disk files.
   #
   def vdlVcConnection(thumb_print)
-    require 'VixDiskLib'
+    require 'VixDiskLib/VixDiskLib'
 
     VixDiskLib.init(->(s) { $vim_log.info  "VMware(VixDiskLib): #{s}" },
                     ->(s) { $vim_log.warn  "VMware(VixDiskLib): #{s}" },

--- a/lib/gems/pending/VixDiskLib/VixDiskLib.rb
+++ b/lib/gems/pending/VixDiskLib/VixDiskLib.rb
@@ -15,8 +15,6 @@ class VixDiskLibError < RuntimeError
 end
 
 SERVER_PATH = File.expand_path(__dir__)
-LOG_DIR     = ENV["LOG"]
-LOG_FILE    = File.join(LOG_DIR, "vim.log")
 
 class VixDiskLib
   VIXDISKLIB_FLAG_OPEN_READ_ONLY = FFI::VixDiskLib::API::VIXDISKLIB_FLAG_OPEN_READ_ONLY
@@ -97,6 +95,8 @@ class VixDiskLib
     end
 
     my_env["LD_LIBRARY_PATH"] = (my_env["LD_LIBRARY_PATH"].to_s.split(':') << VIXDISKLIB_PATH).compact.join(":")
+    raise VixDiskLibError, "VixDiskLib.connect() failed: No $vim_log defined" unless $vim_log
+    my_env["LOG_FILE"] = $vim_log.logdev.filename.to_s
     my_env
   end
 
@@ -111,7 +111,7 @@ class VixDiskLib
     server_cmd = "ruby #{SERVER_PATH}/VixDiskLibServer.rb"
     $vim_log.info "VixDiskLib.start_service: running command = #{server_cmd}"
     pid = Kernel.spawn(my_env, server_cmd,
-                       [:out, :err]     => [LOG_FILE, "a"],
+                       [:out, :err]     => [my_env["LOG_FILE"], "a"],
                        :unsetenv_others => true,
                        3                => uri_writer,
                        4                => proc_reader)

--- a/lib/gems/pending/VixDiskLib/VixDiskLib.rb
+++ b/lib/gems/pending/VixDiskLib/VixDiskLib.rb
@@ -15,8 +15,7 @@ class VixDiskLibError < RuntimeError
 end
 
 SERVER_PATH = File.expand_path(__dir__)
-MIQ_ROOT    = File.expand_path(File.join(SERVER_PATH, "../../.."))
-LOG_DIR     = File.join(MIQ_ROOT, "log")
+LOG_DIR     = ENV["LOG"]
 LOG_FILE    = File.join(LOG_DIR, "vim.log")
 
 class VixDiskLib

--- a/lib/gems/pending/VixDiskLib/VixDiskLibServer.rb
+++ b/lib/gems/pending/VixDiskLib/VixDiskLibServer.rb
@@ -13,8 +13,7 @@ require 'VixDiskLib/vdl_wrapper'
 class VixDiskLibError < RuntimeError
 end
 
-LOG_DIR     = ENV["LOG"]
-LOG_FILE    = File.join(LOG_DIR, "vim.log")
+LOG_FILE    = ENV["LOG_FILE"]
 
 $vim_log = VMDBLogger.new LOG_FILE
 

--- a/lib/gems/pending/VixDiskLib/VixDiskLibServer.rb
+++ b/lib/gems/pending/VixDiskLib/VixDiskLibServer.rb
@@ -13,8 +13,7 @@ require 'VixDiskLib/vdl_wrapper'
 class VixDiskLibError < RuntimeError
 end
 
-MIQ_ROOT    = File.expand_path(File.join(__dir__, "../../.."))
-LOG_DIR     = File.join(MIQ_ROOT, "log")
+LOG_DIR     = ENV["LOG"]
 LOG_FILE    = File.join(LOG_DIR, "vim.log")
 
 $vim_log = VMDBLogger.new LOG_FILE

--- a/lib/gems/pending/VixDiskLib/vdl_wrapper.rb
+++ b/lib/gems/pending/VixDiskLib/vdl_wrapper.rb
@@ -6,8 +6,7 @@ require 'log4r'
 require 'time'
 require 'util/vmdb-logger'
 
-MIQ_ROOT    = File.expand_path(File.join(__dir__, "../../.."))
-LOG_DIR     = File.join(MIQ_ROOT, "log")
+LOG_DIR     = ENV["LOG"]
 LOG_FILE    = File.join(LOG_DIR, "vim.log")
 
 $vim_log = VMDBLogger.new LOG_FILE

--- a/lib/gems/pending/VixDiskLib/vdl_wrapper.rb
+++ b/lib/gems/pending/VixDiskLib/vdl_wrapper.rb
@@ -6,8 +6,7 @@ require 'log4r'
 require 'time'
 require 'util/vmdb-logger'
 
-LOG_DIR     = ENV["LOG"]
-LOG_FILE    = File.join(LOG_DIR, "vim.log")
+LOG_FILE    = ENV["LOG_FILE"]
 
 $vim_log = VMDBLogger.new LOG_FILE
 


### PR DESCRIPTION
2 types of fixes to the VixDiskLib code path are needed due to the
creation of the manageiq-gems-pending gem.

1) All requires of VixDiskLib require a relative path - require "VixDiskLib/VixDiskLib".
2) Since the VixDiskLib server does not use the Rails Root some acrobatics
   were used to get the log directory.  These must change (and are probably better here
   than previously used)

@bdunne @Fryguy @roliveri please review and merge (and then do whatever gem magic is required if any)