### PR TITLE
Remove warnings

### DIFF
--- a/lib/gems/pending/VMwareWebService/MiqVimBroker.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimBroker.rb
@@ -517,7 +517,7 @@ class MiqVimBroker
     if @mode == :client
       begin
         return @broker.serverAlive?
-      rescue DRb::DRbConnError => err
+      rescue DRb::DRbConnError
         return false
       end
     end

--- a/lib/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -2014,7 +2014,7 @@ class MiqVimInventory < MiqVimClientBase
 
     begin
       dsPath = dsName2path(ds)
-    rescue => err
+    rescue
       return nil
     end
 
@@ -2048,7 +2048,7 @@ class MiqVimInventory < MiqVimClientBase
           fVms.each do |vmMo|
             return o['name'] if vmMor == vmMo
           end
-        rescue => err
+        rescue
           # Ignore errors, keep going and return nil if not found.
         end
       end

--- a/lib/gems/pending/VMwareWebService/VimService.rb
+++ b/lib/gems/pending/VMwareWebService/VimService.rb
@@ -1290,9 +1290,9 @@ class VimService < Handsoap::Service
     if xsiType =~ /^ArrayOf(.*)$/
       nextType = $1
       obj = VimArray.new(xsiType)
-      node.children.each do |c|
-        next if c.blank?
-        obj << unmarshal_response(c, nextType)
+      node.children.each do |child|
+        next if child.blank?
+        obj << unmarshal_response(child, nextType)
       end
       return(obj)
     end
@@ -1300,9 +1300,9 @@ class VimService < Handsoap::Service
     aih = VimMappingRegistry.argInfoMap(xsiType)
     obj = VimHash.new(xsiType)
 
-    node.children.each do |c|
-      next if c.blank?
-      name = c.name.freeze
+    node.children.each do |child|
+      next if child.blank?
+      name = child.name.freeze
 
       ai = aih[name] if aih
 
@@ -1313,9 +1313,9 @@ class VimService < Handsoap::Service
       nextType = (ai ? ai[:type] : nil)
 
       if v.kind_of?(Array)
-        obj[name] << unmarshal_response(c, nextType)
+        obj[name] << unmarshal_response(child, nextType)
       else
-        obj[name] = unmarshal_response(c, nextType)
+        obj[name] = unmarshal_response(child, nextType)
       end
     end
     (obj)

--- a/lib/gems/pending/VolumeManager/LVM/parser.rb
+++ b/lib/gems/pending/VolumeManager/LVM/parser.rb
@@ -90,14 +90,12 @@ class Lvm2MdParser
   def parseObj(parent, name)
     val = @mda.shift
 
-    rv = case val
-         when HASH_START
-           parent[name] = parseHash
-         when ARRAY_START
-           parent[name] = parseArray
-         else
-           parent[name] = parseVal(val)
-         end
+    parent[name] =
+      case val
+      when HASH_START  then parseHash
+      when ARRAY_START then parseArray
+      else                  parseVal(val)
+      end
   end
 
   def parseVal(val)

--- a/lib/gems/pending/VolumeManager/MiqLdm.rb
+++ b/lib/gems/pending/VolumeManager/MiqLdm.rb
@@ -475,7 +475,7 @@ if __FILE__ == $0
     exit(1)
   end
 
-  parts = disk.getPartitions
+  # parts = disk.getPartitions
 
   puts "Disk type: #{disk.diskType}"
   puts "Disk partition type: #{disk.partType}"

--- a/lib/gems/pending/VolumeManager/MiqVolumeManager.rb
+++ b/lib/gems/pending/VolumeManager/MiqVolumeManager.rb
@@ -251,19 +251,19 @@ class MiqVolumeManager
 
       pvs = vg.add_element 'physical'
       vgo.physicalVolumes.each do |pvn, pvo|
-        pv = pvs.add_element('volume',                   "name"              => pvn,
-                                                         "uid"               => pvo.pvId,
-                                                         "controller"        => pvo.diskObj.hwId,
-                                                         "os_name"           => pvo.device,
-                                                         "physical_extents"  => pvo.peCount,
-                                                         "virtual_disk_file" => pvo.diskObj.dInfo.fileName)
+        pvs.add_element('volume', "name"              => pvn,
+                                  "uid"               => pvo.pvId,
+                                  "controller"        => pvo.diskObj.hwId,
+                                  "os_name"           => pvo.device,
+                                  "physical_extents"  => pvo.peCount,
+                                  "virtual_disk_file" => pvo.diskObj.dInfo.fileName)
         pext += pvo.peCount
       end
 
       lvs = vg.add_element 'logical'
       vgo.logicalVolumes.each do |lvn, lvo|
-        lv = lvs.add_element('volume',                   "name" => lvn,
-                                                         "uid"  => lvo.lvId)
+        lvs.add_element('volume', "name" => lvn,
+                                  "uid"  => lvo.lvId)
         lvo.segments.each { |s| lext += s.extentCount }
       end
 

--- a/lib/gems/pending/db/MiqBdb/MiqBdbBtree.rb
+++ b/lib/gems/pending/db/MiqBdb/MiqBdbBtree.rb
@@ -182,8 +182,8 @@ module MiqBerkeleyDB
       # 00-01: Key/data item length
       #    02: Page type AND DELETE FLAG
       #        Data Follows
-      len  = page.buf[entryOffset(index, page), 2].unpack('S')[0]
-      data = page.buf[entryOffset(index, page) + 3, len].unpack("A#{len}")[0]
+      len = page.buf[entryOffset(index, page), 2].unpack('S')[0]
+      page.buf[entryOffset(index, page) + 3, len].unpack("A#{len}")[0]
     end
 
     def entryDataOverflow(index, page)

--- a/lib/gems/pending/disk/DiskProbe.rb
+++ b/lib/gems/pending/disk/DiskProbe.rb
@@ -43,7 +43,6 @@ module DiskProbe
 
     fname = disk.dInfo.fileName rescue ""
 
-    mod = nil
     probes.each do |pmodstr|
       $log.debug "MIQ(DiskProbe-getDiskModForDisk) Disk probe attempting [#{pmodstr}] for [#{fname}]"
       require_relative "modules/#{pmodstr}"

--- a/lib/gems/pending/fs/MiqMountManager.rb
+++ b/lib/gems/pending/fs/MiqMountManager.rb
@@ -77,7 +77,7 @@ class MiqMountManager < MiqFS
 
   # Return free space in file system.
   def freeBytes
-    fs, p = getFsPath(@cwd)
+    fs, _p = getFsPath(@cwd)
     fs.freeBytes
   end
 
@@ -190,7 +190,7 @@ class MiqMountManager < MiqFS
   def toXml(doc = nil)
     doc = MiqXml.createDoc(nil) unless doc
 
-    fses = doc.add_element 'FileSystems'
+    doc.add_element 'FileSystems'
     @fileSystems.each do |fsd|
       $miqOut.puts "FS: #{fsd.fsSpec}, Mounted on: #{fsd.mountPoint}, Type: #{fsd.fs.fsType}, Free bytes: #{fsd.fs.freeBytes}"
     end

--- a/lib/gems/pending/metadata/MIQExtract/MIQExtract.rb
+++ b/lib/gems/pending/metadata/MIQExtract/MIQExtract.rb
@@ -176,7 +176,7 @@ class MIQExtract
         # Log each child snapshot element
         s.find_each("child::snapshot") { |ss| $log.info "Snapshot details:  id:[#{ss.attributes['uid']}]  Name:[#{ss.attributes['displayname']}]" }
       end
-    rescue => e
+    rescue # => e
       # $log.error e
     end
 
@@ -269,7 +269,7 @@ class MIQExtract
     # scanPath = "c:/program files"
     scanPath = "c:/program files/Java/jdk1.5.0_12/jre/lib"
     md5 = MD5deep.new(@systemFs, 'versioninfo' => true, 'imports' => true)
-    xml = md5.scan(scanPath, scanPath)
+    md5.scan(scanPath, scanPath)
   end
 
   def getBaseConfigName

--- a/lib/gems/pending/metadata/VMMount/VMMount.rb
+++ b/lib/gems/pending/metadata/VMMount/VMMount.rb
@@ -44,7 +44,7 @@ class VMMount
             Win32::SystemPath.systemRoot(fsPartitions)
             @fs = fsPartitions
             break
-          rescue => err
+          rescue
             # $log.warn "No Windows partition here."
           end
         end

--- a/lib/gems/pending/metadata/util/md5deep.rb
+++ b/lib/gems/pending/metadata/util/md5deep.rb
@@ -48,7 +48,7 @@ class MD5deep
 
   def self.scan_glob(fs, filename, options = {})
     md5 = MD5deep.new(fs, options)
-    xml = md5.scan_glob(filename)
+    md5.scan_glob(filename)
   end
 
   def scan_glob(filename)
@@ -77,8 +77,6 @@ class MD5deep
   end
 
   def read_fs(path, xmlNode)
-    statHash = {}
-
     if @fs
       @fs.dirForeach(path)  { |x| processFile(path, x, xmlNode) }
       @fs.dirForeach(path)  { |x| processDir(path,  x, xmlNode) }
@@ -244,7 +242,6 @@ if __FILE__ == $0
 
   # Mount VM Image to a real drive letter
   #  mountNative, startPath = false, "M:/WINDOWS/system32/mui"
-  startPath = "c:/windows/system32"
   vmHDImage = "D:\\Virtual Machines\\VC20\\Windows Server 2003 Standard Edition.vmx"
 
   begin

--- a/lib/gems/pending/metadata/util/md5deep.rb
+++ b/lib/gems/pending/metadata/util/md5deep.rb
@@ -14,7 +14,7 @@ class MD5deep
     @fullDirCount = 0
     # Create XML document
     @xml = XmlHash.createDoc(:filesystem)
-    @fs = fs if fs.kind_of?(MiqFS)
+    @fs = fs.kind_of?(MiqFS) ? fs : nil
 
     # Read optional parameters if they exist in the options hash
     @opts = {'versioninfo' => true, 'imports' => true, 'contents' => false,

--- a/lib/gems/pending/metadata/util/win32/Win32Software.rb
+++ b/lib/gems/pending/metadata/util/win32/Win32Software.rb
@@ -268,7 +268,7 @@ module MiqWin32
             #  ie = e1.add_element("image",{"file"=>fileName, "count"=>peData.icons.length.to_s, "md5"=>Digest::MD5.hexdigest(peData.icons[0])})
             #  addIconData(ie, peData, iconNode)
             # end
-          rescue Exception => err
+          rescue Exception # => err
             # $log.debug "(Win32Software-postProcessApps) - file:[#{fileName}] - error:[#{err.to_s}]"
           ensure
             fh.close if fh

--- a/lib/gems/pending/metadata/util/win32/ms-registry.rb
+++ b/lib/gems/pending/metadata/util/win32/ms-registry.rb
@@ -230,7 +230,7 @@ class MSRegHive
     # Process all values
     if nkHash[:num_values] > 0
       vkOffset = nkHash[:values_offset]
-      for i in 1..nkHash[:num_values]
+      nkHash[:num_values].times do
         vkHash = REGISTRY_STRUCT_VK_OFFSET.decode(read_buffer(vkOffset, SIZEOF_REGISTRY_STRUCT_VK_OFFSET))
         parseRecord(vkHash[:offset_vk], xmlSubNode, fqName, level)
         vkOffset += SIZEOF_REGISTRY_STRUCT_VK_OFFSET
@@ -253,7 +253,7 @@ class MSRegHive
 
     if riHash[:num_keys] > 0
       key_offset = offset + SIZEOF_REGISTRY_STRUCT_RI
-      for i in 1..riHash[:num_keys]
+      riHash[:num_keys].times do
         hash = REGISTRY_STRUCT_RI_OFFSET.decode(read_buffer(key_offset, SIZEOF_REGISTRY_STRUCT_RI_OFFSET))
         parseRecord hash[:offset_ri], xmlNode, fqName, level
         key_offset += SIZEOF_REGISTRY_STRUCT_RI_OFFSET
@@ -267,7 +267,7 @@ class MSRegHive
 
     if lfHash[:num_keys] > 0
       key_offset = offset + SIZEOF_REGISTRY_STRUCT_LF
-      for i in 1..lfHash[:num_keys]
+      lfHash[:num_keys].times do
         hash = REGISTRY_STRUCT_LF_HASH.decode(read_buffer(key_offset, SIZEOF_REGISTRY_STRUCT_LF_HASH))
         parseRecord hash[:offset_nk], xmlNode, fqName, level
         key_offset += SIZEOF_REGISTRY_STRUCT_LF_HASH
@@ -281,7 +281,7 @@ class MSRegHive
 
     if lhHash[:num_keys] > 0
       key_offset = offset + SIZEOF_REGISTRY_STRUCT_LH
-      for i in 1..lhHash[:num_keys]
+      lhHash[:num_keys].times do
         hash = REGISTRY_STRUCT_LH_HASH.decode(read_buffer(key_offset, SIZEOF_REGISTRY_STRUCT_LH_HASH))
         parseRecord hash[:offset_nk], xmlNode, fqName, level
         key_offset += SIZEOF_REGISTRY_STRUCT_LH_HASH

--- a/lib/gems/pending/metadata/util/win32/peheader.rb
+++ b/lib/gems/pending/metadata/util/win32/peheader.rb
@@ -21,6 +21,7 @@ class PEheader
     @fname = path
     @dataDirs = []
     @sectionTable = []
+    @baseResDir = nil
 
     if path.class != String
       @fHnd = path
@@ -90,19 +91,19 @@ class PEheader
   end
 
   def imports
-    @import_array || @import_array = getImports
+    @import_array ||= getImports
   end
 
   def icons
-    @icon_array || @icon_array = getIcons(@fBuf)
+    @icon_array ||= getIcons(@fBuf)
   end
 
   def messagetables
-    @messagetable_hash || @messagetable_hash = getMessagetables
+    @messagetable_hash ||= getMessagetables
   end
 
   def versioninfo
-    @versioninfo_array || @versioninfo_array = getVersioninfo
+    @versioninfo_array ||= getVersioninfo
   end
 
   # //////////////////////////////////////////////////////////////////////////

--- a/lib/gems/pending/util/miq-logger.rb
+++ b/lib/gems/pending/util/miq-logger.rb
@@ -24,7 +24,6 @@ if $log.nil?
       log = Log4r::Logger[logName]
       if log.nil?
         log = Log4r::Logger.new(logName)
-        p = defaultFormatter
 
         # Initialize logging header
         log.miqLogHeader(fileName, false)

--- a/lib/gems/pending/util/miq-logger.rb
+++ b/lib/gems/pending/util/miq-logger.rb
@@ -119,6 +119,12 @@ if $log.nil?
 
   module Log4r
     class Logger
+      alias :orig_initialize :initialize
+      def initialize(*args)
+        orig_initialize(*args)
+        @miqFileName = nil
+      end
+
       def summary(args)
         summ args
       end

--- a/lib/gems/pending/util/miq-system.rb
+++ b/lib/gems/pending/util/miq-system.rb
@@ -15,7 +15,7 @@ class MiqSystem
 
       begin
         mtime = File.mtime(filename)
-      rescue Errno::ENOENT => err
+      rescue Errno::ENOENT
         @@cpu_usage_vmstat_output_mtime = @@cpu_usage_computed_value = nil
         return nil
       end
@@ -131,7 +131,7 @@ class MiqSystem
       AwesomeSpawn.run!("df", :params => ["-T", "-P", "-i", file]).output.lines.each do |line|
         lArray = line.strip.split(" ")
         next if lArray.length != 7
-        fsname, type, total, used, free, used_percentage, mount_point = lArray
+        fsname, _type, total, used, free, used_percentage, _mount_point = lArray
         next unless total =~ /[0-9]+/
         h = result.detect { |hh| hh[:filesystem] == fsname }
         next if h.nil?

--- a/lib/gems/pending/util/xml/miq_nokogiri.rb
+++ b/lib/gems/pending/util/xml/miq_nokogiri.rb
@@ -133,7 +133,7 @@ begin
 
         def self.loadFile(filename)
           Nokogiri::XML::Document.new(filename)
-        rescue => err
+        rescue
           $log.warn "Unable to load XML document with Nokogiri, retrying with REXML" if $log
           from_xml(filename, true)
         end
@@ -144,7 +144,7 @@ begin
           begin
             # Create a parser and pass in the string data
             Nokogiri::XML::Document.parse(data, nil, nil, Nokogiri::XML::ParseOptions::RECOVER)
-          rescue => err
+          rescue
             from_xml(data, false)
           end
         end

--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -86,7 +86,6 @@ class MIQRexml
 
   def self.findElementInt(paths, ele)
     if paths.length > 0
-      found = false
       searchStr = paths[0]
       paths = paths[1..paths.length]
       # puts "Search String: #{searchStr}"

--- a/lib/gems/pending/util/xml/xml_diff.rb
+++ b/lib/gems/pending/util/xml/xml_diff.rb
@@ -109,7 +109,7 @@ module MiqXmlDiff
   end
 
   def miq_compare_get_element_index(ele)
-    p = ele.parent
+    # p = ele.parent
     # n = p.elements.index(ele)
     0
   end

--- a/lib/gems/pending/util/xml/xml_hash.rb
+++ b/lib/gems/pending/util/xml/xml_hash.rb
@@ -219,7 +219,7 @@ module XmlHash
 
     def child=(object)
       if object.kind_of?(Hash)
-        x = self[:child] << object
+        self[:child] << object
         object.parent = self
       elsif object.respond_to?(:to_xml)
       else
@@ -536,7 +536,6 @@ module XmlHash
 
     def self.findElementInt(paths, ele)
       if paths.length > 0
-        found = false
         searchStr = paths[0]
         paths = paths[1..paths.length]
         # puts "Search String: #{searchStr}"

--- a/lib/gems/pending/util/xml/xml_hash.rb
+++ b/lib/gems/pending/util/xml/xml_hash.rb
@@ -172,8 +172,7 @@ module XmlHash
     end
 
     def elements
-      return @elements if @elements
-      @elements = Elements.new(self)
+      @elements ||= Elements.new(self)
     end
 
     def has_elements?
@@ -320,8 +319,7 @@ module XmlHash
     end
 
     def elements
-      return @elements if @elements
-      @elements = Elements.new(self)
+      @elements ||= Elements.new(self)
     end
 
     def parent

--- a/lib/gems/pending/util/xml/xml_utils.rb
+++ b/lib/gems/pending/util/xml/xml_utils.rb
@@ -44,7 +44,6 @@ class XmlFind
 
   def self.findElementInt(paths, ele)
     if paths.length > 0
-      found = false
       searchStr = paths[0]
       paths = paths[1..paths.length]
       # puts "Search String: #{searchStr}"

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -70,9 +70,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "zip-zip",                 "~>0.3.0"
 
   s.add_development_dependency "camcorder"
-  s.add_development_dependency "codeclimate-test-reporter", "~>1.0.0"
   s.add_development_dependency "rspec",        "~>3.5.0"
-  s.add_development_dependency "simplecov"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "timecop",      "~>0.7.3"
   s.add_development_dependency "vcr",          "~>3.0.0"

--- a/test/extract/tc_registry.rb
+++ b/test/extract/tc_registry.rb
@@ -148,8 +148,7 @@ module Extract
         currPath = File.join(currPath, p) unless p.nil?
         fs.chdir(currPath)
         fs.dirEntries(fs.pwd).each do |name|
-          item = fs.fileDirectory?(name) ? "<DIR> #{name}" : name
-          # $log.debug item
+          fs.fileDirectory?(name) ? "<DIR> #{name}" : name
         end
       end
     end

--- a/test/xml/tc_nokogiri.rb
+++ b/test/xml/tc_nokogiri.rb
@@ -8,7 +8,7 @@ class NokogiriXmlMethods < Minitest::Test
 
   def setup
     @xml_klass = Nokogiri::XML
-    @xml_string = default_test_xml if @xml_string.nil?
+    @xml_string ||= default_test_xml
     @xml = MiqXml.load(@xml_string, :nokogiri)
   end
 

--- a/test/xml/tc_nokogiri.rb
+++ b/test/xml/tc_nokogiri.rb
@@ -177,7 +177,8 @@ class NokogiriXmlMethods < Minitest::Test
     xml = @xml
     assert_kind_of(@xml_klass::Document, xml)
 
-    frozen_text = "A&P".freeze
+    "A&P".freeze
+    # frozen_text = "A&P".freeze
     # assert_nothing_raised {xml.root.text = frozen_text}
     # TODO: Fix decoding of special characters
     # assert_equal("A&P", xml.root.text)

--- a/test/xml/tc_rexml.rb
+++ b/test/xml/tc_rexml.rb
@@ -7,7 +7,7 @@ class TestBaseXmlMethods < Minitest::Test
 
   def setup
     @xml_klass = REXML
-    @xml_string = default_test_xml if @xml_string.nil?
+    @xml_string ||= default_test_xml
     @xml = MiqXml.load(@xml_string, @xml_klass)
   end
 

--- a/test/xml/tc_xmlhash_methods.rb
+++ b/test/xml/tc_xmlhash_methods.rb
@@ -156,7 +156,7 @@ class TestXmlHashMethods < Minitest::Test
     assert_respond_to(xml, :xmlPatch)
     xml_old = XmlHash.load(simple_xml_text)
     stats = {}
-    xml_diff = xml.xmlDiff(xml_old, stats)
+    xml.xmlDiff(xml_old, stats)
     assert_equal(0, stats[:adds])
     assert_equal(0, stats[:deletes])
     assert_equal(0, stats[:updates])


### PR DESCRIPTION
As of rake 11, warnings are on by default, as this is why our output is flooded.  To go back to the old way we can set `t.warning = false` in the Rake task, but I want to remove a few before disabling.  There are still more, but this trims out a lot.

@bdunne Please review.