### PR TITLE
Drop pglogical subscriptions before restore

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -345,8 +345,6 @@ Static Network Configuration
 
       when I18n.t("advanced_settings.dbrestore")
         say("#{selection}\n\n")
-        ApplianceConsole::Utilities.bail_if_db_connections "preventing a database restore"
-
         task_params = []
         uri = nil
 
@@ -393,6 +391,8 @@ Static Network Configuration
             File.delete(DB_RESTORE_FILE)
           elsif !rake_success
             say("\nDatabase restore failed")
+            connections = ApplianceConsole::Utilities.db_connections - 1
+            say("\nThere are #{connections} connection preventing a database restore") if connections > 0
           end
         end
         press_any_key

--- a/spec/util/postgres_admin_spec.rb
+++ b/spec/util/postgres_admin_spec.rb
@@ -128,6 +128,13 @@ describe PostgresAdmin do
     end
   end
 
+  describe ".before_restore" do
+    it "doesn't raise if runcmd does" do
+      expect(described_class).to receive(:runcmd).and_raise(AwesomeSpawn::CommandResultError.new("", ""))
+      expect { described_class.before_restore({}) }.to_not raise_error
+    end
+  end
+
   describe ".database_in_recovery?" do
     before do
       begin


### PR DESCRIPTION
pglogical subscriptions cause a postgresql worker process to hold open connections to the database. If we attempt to drop the database while we still have subscriptions, we will always fail.

This commit removes any existing subscriptions before attempting a restore and ignores the failures in the case that pglogical is not being used. This allows the database restore to complete cleanly.

https://bugzilla.redhat.com/show_bug.cgi?id=1393049

@Fryguy @gtanzillo please review