### PR TITLE
Add Datastore maintenanceMode to VMwareWebService

### DIFF
--- a/lib/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -47,6 +47,7 @@ class MiqVimInventory < MiqVimClientBase
       deleteProperty(:HostSystem, "capability.vmotionWithStorageVMotionSupported")
 
       deleteProperty(:Datastore, "summary.uncommitted")
+      deleteProperty(:Datastore, "summary.maintenanceMode")
 
       deleteProperty(:VirtualMachine, "config.cpuHotAddEnabled")
       deleteProperty(:VirtualMachine, "config.cpuHotRemoveEnabled")
@@ -64,11 +65,17 @@ class MiqVimInventory < MiqVimClientBase
         deleteProperty(:HostSystem, "config.dateTimeInfo")
       end
     else
-      if @v4 && cacheScope != :cache_scope_event_monitor
+      if @v4
         @propMap = dupProps(@propMap)
-        addProperty(:VirtualMachine, "runtime.memoryOverhead")
-        deleteProperty(:VirtualMachine, "config.hardware.numCoresPerSocket")
+
+        deleteProperty(:Datastore, "summary.maintenanceMode")
+
+        if cacheScope != :cache_scope_event_monitor
+          addProperty(:VirtualMachine, "runtime.memoryOverhead")
+          deleteProperty(:VirtualMachine, "config.hardware.numCoresPerSocket")
+        end
       end
+
       @propMap = @propMap.merge(PropMap4)
     end
 

--- a/lib/gems/pending/VMwareWebService/VimPropMaps.rb
+++ b/lib/gems/pending/VMwareWebService/VimPropMaps.rb
@@ -344,6 +344,7 @@ module VimPropMaps
         "summary.capacity",
         "summary.datastore",
         "summary.freeSpace",
+        "summary.maintenanceMode",
         "summary.multipleHostAccess",
         "summary.name",
         "summary.type",
@@ -499,6 +500,7 @@ module VimPropMaps
         "summary.capacity",
         "summary.datastore",
         "summary.freeSpace",
+        "summary.maintenanceMode",
         "summary.uncommitted",
         "parent"
       ]


### PR DESCRIPTION
Datastore maintenance mode was added in vSphere 5.0 and allows the administrator to mark a datastore that is part of a datastore cluster as being in maintenance mode.  The intention is that this can be used to remove datastores that are in maintenance mode from the list of eligible targets for provisioning.

Datastore not in maintenance mode:
![screenshot from 2016-11-28 12-29-31](https://cloud.githubusercontent.com/assets/12851112/20678904/8684c760-b566-11e6-9db8-cf49c47d8fd7.png)

Datastore in maintenance mode:
![screenshot from 2016-11-28 12-29-23](https://cloud.githubusercontent.com/assets/12851112/20678914/8b9d5d0c-b566-11e6-9e5e-344a32a48d85.png)

VC SDK link: http://pubs.vmware.com/vsphere-50/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc_50%2Fvim.Datastore.Summary.html
```
maintenanceMode*	xsd:string	
The current maintenance mode state of the datastore. The set of possible values is described in DatastoreSummaryMaintenanceModeState.
Since vSphere API 5.0
```

https://bugzilla.redhat.com/show_bug.cgi?id=1394909