### PR TITLE
Refactor VMwareWebService ObjectSet into a module

### DIFF
--- a/lib/gems/pending/VMwareWebService/MiqVimCoreUpdater.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimCoreUpdater.rb
@@ -1,10 +1,12 @@
 require 'VMwareWebService/MiqVimClientBase'
 require 'VMwareWebService/MiqVimDump'
 require 'VMwareWebService/VimPropMaps'
+require 'VMwareWebService/MiqVimObjectSet'
 
 class MiqVimCoreUpdater < MiqVimClientBase
   include VimPropMaps
   include MiqVimDump
+  include MiqVimObjectSet
 
   def initialize(server, username, password, propMap = nil, maxWait = 60)
     super(server, username, password)
@@ -33,123 +35,6 @@ class MiqVimCoreUpdater < MiqVimClientBase
     property.split('.').each { |p| return if pm.include?(p) }
     @propMap[key][:props] << property
   end
-
-  #
-  # Construct an ObjectSpec to traverse the entire VI inventory tree.
-  #
-  def objectSet
-    #
-    # Traverse VirtualApp to Vm.
-    #
-    virtualAppTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name     = "virtualAppTraversalSpec"
-      ts.type     = "VirtualApp"
-      ts.path     = "vm"
-      ts.skip     = "false"
-    end unless @v2
-
-    #
-    # Traverse ResourcePool to ResourcePool and VirtualApp.
-    #
-    resourcePoolTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name     = "resourcePoolTraversalSpec"
-      ts.type     = "ResourcePool"
-      ts.path     = "resourcePool"
-      ts.skip     = "false"
-      ts.selectSet  = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "resourcePoolTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse ComputeResource to ResourcePool.
-    #
-    computeResourceRpTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name        = "computeResourceRpTraversalSpec"
-      ts.type        = "ComputeResource"
-      ts.path        = "resourcePool"
-      ts.skip        = "false"
-      ts.selectSet   = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "resourcePoolTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse ComputeResource to host.
-    #
-    computeResourceHostTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name     = "computeResourceHostTraversalSpec"
-      ts.type     = "ComputeResource"
-      ts.path     = "host"
-      ts.skip     = "false"
-    end
-
-    #
-    # Traverse Datacenter to host folder.
-    #
-    datacenterHostTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name     = "datacenterHostTraversalSpec"
-      ts.type     = "Datacenter"
-      ts.path     = "hostFolder"
-      ts.skip     = "false"
-      ts.selectSet  = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse Datacenter to VM folder.
-    #
-    datacenterVmTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name     = "datacenterVmTraversalSpec"
-      ts.type     = "Datacenter"
-      ts.path     = "vmFolder"
-      ts.skip     = "false"
-      ts.selectSet  = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse Datacenter to Datastore.
-    #
-    datacenterDsTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name     = "datacenterDsTraversalSpec"
-      ts.type     = "Datacenter"
-      ts.path     = "datastore"
-      ts.skip     = "false"
-    end
-
-    #
-    # Traverse Folder to children.
-    #
-    folderTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name     = "folderTraversalSpec"
-      ts.type     = "Folder"
-      ts.path     = "childEntity"
-      ts.skip     = "false"
-      ts.selectSet  = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
-        ssa << datacenterHostTs
-        ssa << datacenterVmTs
-        ssa << datacenterDsTs
-        ssa << computeResourceRpTs
-        ssa << computeResourceHostTs
-        ssa << resourcePoolTs
-        ssa << virtualAppTs unless @v2
-      end
-    end
-
-    aOobjSpec = VimArray.new("ArrayOfObjectSpec") do |osa|
-      osa << VimHash.new("ObjectSpec") do |os|
-        os.obj      = @sic.rootFolder
-        os.skip     = "false"
-        os.selectSet  = VimArray.new("ArrayOfSelectionSpec") { |ssa| ssa << folderTs }
-      end
-    end
-
-    (aOobjSpec)
-  end # def objectSet
 
   def updateSpec
     VimHash.new("PropertyFilterSpec") do |pfs|

--- a/lib/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -4,6 +4,7 @@ require 'enumerator'
 require 'VMwareWebService/MiqVimClientBase'
 require 'VMwareWebService/MiqVimDump'
 require 'VMwareWebService/VimPropMaps'
+require 'VMwareWebService/MiqVimObjectSet'
 
 class MiqVimInventory < MiqVimClientBase
   attr_reader :cacheLock, :configLock
@@ -13,6 +14,7 @@ class MiqVimInventory < MiqVimClientBase
 
   include VimPropMaps
   include MiqVimDump
+  include MiqVimObjectSet
 
   @@selectorHash = {}
   @@cacheScope   = :cache_scope_full
@@ -173,151 +175,6 @@ class MiqVimInventory < MiqVimClientBase
     end
     totalCacheSz
   end
-
-  #
-  # Construct an ObjectSpec to traverse the entire VI inventory tree.
-  #
-  def objectSet
-    #
-    # Traverse VirtualApp to Vm.
-    #
-    virtualAppTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name = "virtualAppTraversalSpec"
-      ts.type = "VirtualApp"
-      ts.path = "vm"
-      ts.skip = "false"
-    end unless @v2
-
-    #
-    # Traverse ResourcePool to ResourcePool and VirtualApp.
-    #
-    resourcePoolTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name      = "resourcePoolTraversalSpec"
-      ts.type      = "ResourcePool"
-      ts.path      = "resourcePool"
-      ts.skip      = "false"
-      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "resourcePoolTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse ComputeResource to ResourcePool.
-    #
-    computeResourceRpTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name      = "computeResourceRpTraversalSpec"
-      ts.type      = "ComputeResource"
-      ts.path      = "resourcePool"
-      ts.skip      = "false"
-      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "resourcePoolTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse ComputeResource to host.
-    #
-    computeResourceHostTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name = "computeResourceHostTraversalSpec"
-      ts.type = "ComputeResource"
-      ts.path = "host"
-      ts.skip = "false"
-    end
-
-    #
-    # Traverse Datacenter to host folder.
-    #
-    datacenterHostTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name      = "datacenterHostTraversalSpec"
-      ts.type      = "Datacenter"
-      ts.path      = "hostFolder"
-      ts.skip      = "false"
-      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse Datacenter to VM folder.
-    #
-    datacenterVmTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name      = "datacenterVmTraversalSpec"
-      ts.type      = "Datacenter"
-      ts.path      = "vmFolder"
-      ts.skip      = "false"
-      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse Datacenter to Datastore folder.
-    #
-    datacenterDsFolderTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name      = "dcTodf"
-      ts.type      = "Datacenter"
-      ts.path      = "datastoreFolder"
-      ts.skip      = "false"
-      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse Datacenter to Datastore.
-    #
-    datacenterDsTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name = "datacenterDsTraversalSpec"
-      ts.type = "Datacenter"
-      ts.path = "datastore"
-      ts.skip = "false"
-    end
-
-    #
-    # Traverse Datacenter to Network folder
-    #
-    datacenterNetworkFolderTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name = "dcTonf"
-      ts.type = "Datacenter"
-      ts.path = "networkFolder"
-      ts.skip = "false"
-      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
-      end
-    end
-
-    #
-    # Traverse Folder to children.
-    #
-    folderTs = VimHash.new("TraversalSpec") do |ts|
-      ts.name      = "folderTraversalSpec"
-      ts.type      = "Folder"
-      ts.path      = "childEntity"
-      ts.skip      = "false"
-      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
-        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
-        ssa << datacenterHostTs
-        ssa << datacenterVmTs
-        ssa << datacenterDsTs
-        ssa << datacenterDsFolderTs
-        ssa << datacenterNetworkFolderTs
-        ssa << computeResourceRpTs
-        ssa << computeResourceHostTs
-        ssa << resourcePoolTs
-        ssa << virtualAppTs unless @v2
-      end
-    end
-
-    aOobjSpec = VimArray.new("ArrayOfObjectSpec") do |osa|
-      osa << VimHash.new("ObjectSpec") do |os|
-        os.obj       = @sic.rootFolder
-        os.skip      = "false"
-        os.selectSet = VimArray.new("ArrayOfSelectionSpec") { |ssa| ssa << folderTs }
-      end
-    end
-
-    (aOobjSpec)
-  end # def objectSet
 
   #
   # Construct an array of PropertySpec objects to retrieve the MORs for all the

--- a/lib/gems/pending/VMwareWebService/MiqVimObjectSet.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimObjectSet.rb
@@ -1,0 +1,146 @@
+module MiqVimObjectSet
+  #
+  # Construct an ObjectSpec to traverse the entire VI inventory tree.
+  #
+  def objectSet
+    #
+    # Traverse VirtualApp to Vm.
+    #
+    virtualAppTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name = "virtualAppTraversalSpec"
+      ts.type = "VirtualApp"
+      ts.path = "vm"
+      ts.skip = "false"
+    end unless @v2
+
+    #
+    # Traverse ResourcePool to ResourcePool and VirtualApp.
+    #
+    resourcePoolTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name      = "resourcePoolTraversalSpec"
+      ts.type      = "ResourcePool"
+      ts.path      = "resourcePool"
+      ts.skip      = "false"
+      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
+        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "resourcePoolTraversalSpec" }
+      end
+    end
+
+    #
+    # Traverse ComputeResource to ResourcePool.
+    #
+    computeResourceRpTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name      = "computeResourceRpTraversalSpec"
+      ts.type      = "ComputeResource"
+      ts.path      = "resourcePool"
+      ts.skip      = "false"
+      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
+        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "resourcePoolTraversalSpec" }
+      end
+    end
+
+    #
+    # Traverse ComputeResource to host.
+    #
+    computeResourceHostTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name = "computeResourceHostTraversalSpec"
+      ts.type = "ComputeResource"
+      ts.path = "host"
+      ts.skip = "false"
+    end
+
+    #
+    # Traverse Datacenter to host folder.
+    #
+    datacenterHostTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name      = "datacenterHostTraversalSpec"
+      ts.type      = "Datacenter"
+      ts.path      = "hostFolder"
+      ts.skip      = "false"
+      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
+        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
+      end
+    end
+
+    #
+    # Traverse Datacenter to VM folder.
+    #
+    datacenterVmTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name      = "datacenterVmTraversalSpec"
+      ts.type      = "Datacenter"
+      ts.path      = "vmFolder"
+      ts.skip      = "false"
+      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
+        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
+      end
+    end
+
+    #
+    # Traverse Datacenter to Datastore folder.
+    #
+    datacenterDsFolderTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name      = "dcTodf"
+      ts.type      = "Datacenter"
+      ts.path      = "datastoreFolder"
+      ts.skip      = "false"
+      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
+        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
+      end
+    end
+
+    #
+    # Traverse Datacenter to Datastore.
+    #
+    datacenterDsTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name = "datacenterDsTraversalSpec"
+      ts.type = "Datacenter"
+      ts.path = "datastore"
+      ts.skip = "false"
+    end
+
+    #
+    # Traverse Datacenter to Network folder
+    #
+    datacenterNetworkFolderTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name = "dcTonf"
+      ts.type = "Datacenter"
+      ts.path = "networkFolder"
+      ts.skip = "false"
+      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
+        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
+      end
+    end
+
+    #
+    # Traverse Folder to children.
+    #
+    folderTs = VimHash.new("TraversalSpec") do |ts|
+      ts.name      = "folderTraversalSpec"
+      ts.type      = "Folder"
+      ts.path      = "childEntity"
+      ts.skip      = "false"
+      ts.selectSet = VimArray.new("ArrayOfSelectionSpec") do |ssa|
+        ssa << VimHash.new("SelectionSpec") { |ss| ss.name = "folderTraversalSpec" }
+        ssa << datacenterHostTs
+        ssa << datacenterVmTs
+        ssa << datacenterDsTs
+        ssa << datacenterDsFolderTs
+        ssa << datacenterNetworkFolderTs
+        ssa << computeResourceRpTs
+        ssa << computeResourceHostTs
+        ssa << resourcePoolTs
+        ssa << virtualAppTs unless @v2
+      end
+    end
+
+    aOobjSpec = VimArray.new("ArrayOfObjectSpec") do |osa|
+      osa << VimHash.new("ObjectSpec") do |os|
+        os.obj       = @sic.rootFolder
+        os.skip      = "false"
+        os.selectSet = VimArray.new("ArrayOfSelectionSpec") { |ssa| ssa << folderTs }
+      end
+    end
+
+    (aOobjSpec)
+  end # def objectSet
+end


### PR DESCRIPTION
The `MiqVimInventory` and `MiqVimCoreUpdater` classes have duplicated `objectSet` methods that define the traversal spec.  This pulls the duplicated code out into a common module.