### PR TITLE
Allow the use of all timezones in the console

### DIFF
--- a/spec/appliance_console/timezone_configuration_spec.rb
+++ b/spec/appliance_console/timezone_configuration_spec.rb
@@ -3,70 +3,63 @@ require "appliance_console/timezone_configuration"
 describe ApplianceConsole::TimezoneConfiguration do
   subject { described_class.new('US/Eastern') }
 
-  context "#ask_questions" do
+  let(:timezone_hash) do
+    {
+      "Africa"  => {
+        "Abidijan" => "Africa/Abidijan"
+      },
+      "America" => {
+        "Argentina" => {
+          "Buenos_Aires" => "America/Argentina/Buenos_Aires"
+        }
+      },
+      "UTC"     => "UTC"
+    }
+  end
+
+  describe "#ask_questions" do
     it "returns true when all user input is provided" do
-      expect(subject).to receive(:ask_timezone_area).and_return(true)
-      expect(subject).to receive(:ask_timezone_city).and_return(true)
+      expect(subject).to receive(:ask_for_timezone).and_return(true)
       expect(subject).to receive(:confirm).and_return(true)
-      expect(subject.ask_questions).to_not be false
-    end
-
-    it "returns false when apply timezone is canceled" do
-      expect(subject).to receive(:ask_timezone_area).and_return(true)
-      expect(subject).to receive(:ask_timezone_city).and_return(true)
-      expect(subject).to receive(:confirm).and_return(false)
-      expect(subject.ask_questions).to be false
-    end
-
-    it "returns false when new city is canceled" do
-      expect(subject).to receive(:ask_timezone_area).and_return(true)
-      expect(subject).to receive(:ask_timezone_city).and_return(false)
-      expect(subject).to_not receive(:confirm)
-      expect(subject.ask_questions).to be false
-    end
-
-    it "returns false when new area is canceled" do
-      expect(subject).to receive(:ask_timezone_area).and_return(false)
-      expect(subject).to_not receive(:ask_timezone_city)
-      expect(subject).to_not receive(:confirm)
-      expect(subject.ask_questions).to be false
+      expect(subject.ask_questions).to be true
     end
   end
 
-  context "#ask_timezone_area" do
-    it "asks for a new timezone area" do
-      expect(subject).to receive(:ask_with_menu).and_return('United States')
-      expect(subject.ask_timezone_area).to be true
-      expect(subject.new_loc).to eq('US')
-    end
-
-    it "returns false when cancel is requested" do
-      expect(subject).to receive(:ask_with_menu).and_return(ApplianceConsole::CANCEL)
-      expect(subject.ask_timezone_area).to be false
-    end
-  end
-
-  context "#ask_timezone_city" do
-    before { subject.instance_variable_set(:@new_loc, 'US') }
-
-    it "asks for a new timezone city" do
-      expect(subject).to receive(:ask_with_menu).and_return('Alaska')
-      expect(subject.ask_timezone_city).to be true
-      expect(subject.new_city).to eq('Alaska')
-    end
-
-    it "returns false when cancel is requested" do
-      expect(subject).to receive(:ask_with_menu).and_return(ApplianceConsole::CANCEL)
-      expect(subject.ask_timezone_city).to be false
-    end
-  end
-
-  context "#confirm" do
+  describe "#ask_for_timezone" do
     before do
-      subject.instance_variable_set(:@tz_area, 'US')
-      subject.instance_variable_set(:@new_city, 'Alaska')
+      expect(subject).to receive(:timezone_hash).and_return(timezone_hash)
+    end
+
+    it "prompts once for non-nested timezones" do
+      expect(subject).to receive(:ask_with_menu).once
+        .with("Geographic Location", %w(Africa America UTC), nil, false)
+        .and_return("UTC")
+
+      expect(subject.ask_for_timezone).to be true
+
+      expect(subject.new_timezone).to eq("UTC")
+    end
+
+    it "prompts multiple times for nested timezones" do
+      expect(subject).to receive(:ask_with_menu)
+        .with("Geographic Location", %w(Africa America UTC), nil, false)
+        .and_return("America").ordered
+      expect(subject).to receive(:ask_with_menu)
+        .with("Geographic Location", ["Argentina"], nil, false)
+        .and_return("Argentina").ordered
+      expect(subject).to receive(:ask_with_menu)
+        .with("Geographic Location", ["Buenos_Aires"], nil, false)
+        .and_return("Buenos_Aires").ordered
+
+      expect(subject.ask_for_timezone).to be true
+
+      expect(subject.new_timezone).to eq("America/Argentina/Buenos_Aires")
+    end
+  end
+
+  describe "#confirm" do
+    before do
       allow(subject).to receive(:clear_screen)
-      allow(subject).to receive(:say)
     end
 
     it "asks to apply timezone" do
@@ -80,7 +73,7 @@ describe ApplianceConsole::TimezoneConfiguration do
     end
   end
 
-  context "#activate" do
+  describe "#activate" do
     before do
       expect(subject).to receive(:log_and_feedback).and_yield
       allow(subject).to receive(:say)
@@ -94,6 +87,13 @@ describe ApplianceConsole::TimezoneConfiguration do
     it "returns false on failure" do
       expect(LinuxAdmin::TimeDate).to receive(:system_timezone=).and_raise(LinuxAdmin::TimeDate::TimeCommandError)
       expect(subject.activate).to be_falsy
+    end
+  end
+
+  describe "#timezone_hash" do
+    it "returns the correct hash" do
+      expect(LinuxAdmin::TimeDate).to receive(:timezones).and_return(%w(Africa/Abidijan UTC America/Argentina/Buenos_Aires))
+      expect(subject.timezone_hash).to eq(timezone_hash)
     end
   end
 end


### PR DESCRIPTION
Previously we had some custom logic about how to find the list of timezones to display to the user.
Instead of that, we can use `LinuxAdmin::TimeDate.timezones` to get the same list.

This also allows the use of timezones which are nested more than two levels (such as `America/Argentina/Buenos_Aires`)

https://bugzilla.redhat.com/show_bug.cgi?id=1356688
@gtanzillo @jvlcek please review