### PR TITLE
Add more detail to the prompt about running evmserverd

### DIFF
--- a/lib/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/internal_database_configuration.rb
@@ -46,7 +46,16 @@ module ApplianceConsole
 
     def ask_questions
       choose_disk
-      self.run_as_evm_server = !ask_yn?("Configure this server as a dedicated database instance")
+      self.run_as_evm_server = !ask_yn?(<<-EOS.gsub!(/^ +/m, ""), "N")
+
+        Should this appliance run as a standalone database server?
+
+        NOTE:
+        * The #{I18n.t("product.name")} application will not be running.
+        * This is required when using highly available database deployments.
+        * CAUTION: This is not reversible.
+
+      EOS
       # TODO: Assume we want to create a region for a new internal database disk
       # until we allow for the internal selection against an already initialized disk.
       create_new_region_questions(false) if run_as_evm_server


### PR DESCRIPTION
This commit adds a default answer and some more details to the prompt about whether the user wants this particular server to run as a standalone database server or as a database server and an application server (evmserverd).

As requested by @bascar 

@Fryguy @gtanzillo please review

-----------------------------------------------------------------

The new screen looks like this:

![newdbconsolequestion](https://cloud.githubusercontent.com/assets/12697904/20773050/04fb3a9e-b71e-11e6-954b-f25c60e0ce1a.png)

