### PR TITLE
Add a port prompt to database setup

### DIFF
--- a/lib/gems/pending/appliance_console/cli.rb
+++ b/lib/gems/pending/appliance_console/cli.rb
@@ -100,6 +100,7 @@ module ApplianceConsole
         opt :region,   "Region Number",      :type => :integer, :short => "r"
         opt :internal, "Internal Database",                     :short => 'i'
         opt :hostname, "Database Hostname",  :type => :string,  :short => 'h'
+        opt :port,     "Database Port",      :type => :integer,                :default => 5432
         opt :username, "Database Username",  :type => :string,  :short => 'U', :default => "root"
         opt :password, "Database Password",  :type => :string,  :short => "p"
         opt :dbname,   "Database Name",      :type => :string,  :short => "d", :default => "vmdb_production"
@@ -188,6 +189,7 @@ module ApplianceConsole
       say "configuring external database"
       config = ApplianceConsole::ExternalDatabaseConfiguration.new({
         :host        => options[:hostname],
+        :port        => options[:port],
         :database    => options[:dbname],
         :region      => options[:region],
         :username    => options[:username],

--- a/lib/gems/pending/appliance_console/database_configuration.rb
+++ b/lib/gems/pending/appliance_console/database_configuration.rb
@@ -28,6 +28,7 @@ module ApplianceConsole
     # 9223372 won't be a full region though, so we're not including it.
     # TODO: This information should be shared outside of appliance console code and MiqRegion.
     REGION_RANGE = 0..9223371
+    DEFAULT_PORT = 5432
 
     include ApplianceConsole::Logging
 
@@ -114,7 +115,7 @@ module ApplianceConsole
 
     def ask_for_database_credentials
       self.host     = ask_for_ip_or_hostname("database hostname or IP address", host) if host.blank? || !local?
-      self.port     = ask_for_integer("port number", nil, default_port) unless local?
+      self.port     = ask_for_integer("port number", nil, port) unless local?
       self.database = just_ask("name of the database on #{host}", database) unless local?
       self.username = just_ask("username", username) unless local?
       count = 0
@@ -273,10 +274,6 @@ FRIENDLY
           raise ArgumentError, "Invalid argument: #{k}"
         end
       end
-    end
-
-    def default_port
-      5432
     end
   end
 end

--- a/lib/gems/pending/appliance_console/database_configuration.rb
+++ b/lib/gems/pending/appliance_console/database_configuration.rb
@@ -141,6 +141,7 @@ Host:     #{host}
 Username: #{username}
 Database: #{database}
 FRIENDLY
+      output << "Port:     #{port}\n" if port
       output << "Region:   #{region}\n" if region
       output
     end

--- a/lib/gems/pending/appliance_console/database_configuration.rb
+++ b/lib/gems/pending/appliance_console/database_configuration.rb
@@ -114,6 +114,7 @@ module ApplianceConsole
 
     def ask_for_database_credentials
       self.host     = ask_for_ip_or_hostname("database hostname or IP address", host) if host.blank? || !local?
+      self.port     = ask_for_integer("port number", nil, default_port) unless local?
       self.database = just_ask("name of the database on #{host}", database) unless local?
       self.username = just_ask("username", username) unless local?
       count = 0
@@ -271,6 +272,10 @@ FRIENDLY
           raise ArgumentError, "Invalid argument: #{k}"
         end
       end
+    end
+
+    def default_port
+      5432
     end
   end
 end

--- a/lib/gems/pending/appliance_console/external_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/external_database_configuration.rb
@@ -9,7 +9,7 @@ module ApplianceConsole
 
     def set_defaults
       self.username = "root"
-      self.port     = default_port
+      self.port     = DEFAULT_PORT
       self.database = "vmdb_production"
     end
 

--- a/lib/gems/pending/appliance_console/external_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/external_database_configuration.rb
@@ -9,6 +9,7 @@ module ApplianceConsole
 
     def set_defaults
       self.username = "root"
+      self.port     = default_port
       self.database = "vmdb_production"
     end
 

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -126,8 +126,8 @@ module ApplianceConsole
       just_ask(prompt, default)
     end
 
-    def ask_for_integer(prompt, range = nil)
-      just_ask(prompt, nil, INT_REGEXP, "an integer", Integer) { |q| q.in = range if range }
+    def ask_for_integer(prompt, range = nil, default = nil)
+      just_ask(prompt, default, INT_REGEXP, "an integer", Integer) { |q| q.in = range if range }
     end
 
     def ask_for_disk(disk_name, verify = true)
@@ -185,7 +185,7 @@ module ApplianceConsole
 
     def just_ask(prompt, default = nil, validate = nil, error_text = nil, klass = nil)
       ask("Enter the #{prompt}: ", klass) do |q|
-        q.default = default if default
+        q.default = default.to_s if default
         q.validate = validate if validate
         q.responses[:not_valid] = error_text ? "Please provide #{error_text}" : "Please provide in the specified format"
         yield q if block_given?

--- a/spec/appliance_console/cli_spec.rb
+++ b/spec/appliance_console/cli_spec.rb
@@ -77,6 +77,7 @@ describe ApplianceConsole::Cli do
     config_double = double(:activate => false)
     expect(ApplianceConsole::ExternalDatabaseConfiguration).to receive(:new)
       .with(:host        => 'host',
+            :port        => 5432,
             :database    => 'db',
             :region      => 1,
             :username    => 'user',
@@ -89,11 +90,12 @@ describe ApplianceConsole::Cli do
   end
 
   it "should handle remote databases (and setup region)" do
-    subject.parse(%w(--hostname host --dbname db --username user --password pass -r 1))
+    subject.parse(%w(--hostname host --port 1234 --dbname db --username user --password pass -r 1))
     expect_v2_key
     expect(subject).to receive(:say)
     expect(ApplianceConsole::ExternalDatabaseConfiguration).to receive(:new)
       .with(:host        => 'host',
+            :port        => 1234,
             :database    => 'db',
             :region      => 1,
             :username    => 'user',
@@ -105,11 +107,12 @@ describe ApplianceConsole::Cli do
   end
 
   it "should handle remote databases (not setting up region)" do
-    subject.parse(%w(--hostname host --dbname db --username user --password pass))
+    subject.parse(%w(--hostname host --port 1234 --dbname db --username user --password pass))
     expect_v2_key
     expect(subject).to receive(:say)
     expect(ApplianceConsole::ExternalDatabaseConfiguration).to receive(:new)
       .with(:host        => 'host',
+            :port        => 1234,
             :database    => 'db',
             :username    => 'user',
             :password    => 'pass',

--- a/spec/appliance_console/database_configuration_spec.rb
+++ b/spec/appliance_console/database_configuration_spec.rb
@@ -146,6 +146,7 @@ describe ApplianceConsole::DatabaseConfiguration do
       subject.password = nil
 
       expect(subject).to receive(:just_ask).with(/hostname/i, "defaulthost", anything, anything).and_return("newhost")
+      expect(subject).to receive(:just_ask).with(/port/i, 5432, anything, anything, anything).and_return(5432)
       expect(subject).to receive(:just_ask).with(/the database/i, "defaultdb").and_return("x")
       expect(subject).to receive(:just_ask).with(/user/i, "defaultuser").and_return("x")
       expect(subject).to receive(:just_ask).with(/password/i, nil).twice.and_return("x")
@@ -157,6 +158,7 @@ describe ApplianceConsole::DatabaseConfiguration do
       subject.password = "defaultpass"
 
       expect(subject).to receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("x")
+      expect(subject).to receive(:just_ask).with(/port/i, anything, anything, anything, anything).and_return(5432)
       expect(subject).to receive(:just_ask).with(/the database/i, anything).and_return("x")
       expect(subject).to receive(:just_ask).with(/user/i,     anything).and_return("x")
       expect(subject).to receive(:just_ask).with(/password/i, "********").and_return("********")
@@ -166,6 +168,7 @@ describe ApplianceConsole::DatabaseConfiguration do
 
     it "should ask for user/password (with confirm) if not local" do
       expect(subject).to receive(:just_ask).with(/hostname/i, anything, anything, anything).and_return("host")
+      expect(subject).to receive(:just_ask).with(/port/i, anything, anything, anything, anything).and_return(5432)
       expect(subject).to receive(:just_ask).with(/the database/i, anything).and_return("x")
       expect(subject).to receive(:just_ask).with(/user/i,     anything).and_return("x")
       expect(subject).to receive(:just_ask).with(/password/i, anything).twice.and_return("the password")

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -398,6 +398,12 @@ describe ApplianceConsole::Prompts do
       expect(subject.ask_for_integer("prompt", 1..10)).to eq(5)
       expect_heard ["Enter the prompt: ", error, prompt + error, prompt]
     end
+
+    it "works with a default" do
+      say ""
+      expect(subject.ask_for_integer("prompt", nil, 1234)).to eq(1234)
+      expect_heard("Enter the prompt: |1234| ")
+    end
   end
 
   context "#ask_yn?" do


### PR DESCRIPTION
This PR makes changes that allow a user of the appliance_console or appliance_console_cli to specify a non-default (other than 5432) port to use when connecting to the database.

This only really applies to external databases as we use a socket when connecting locally.

We default the port to 5432 when configuring an external database and do not prompt for a port when configuring an internal database.

@jvlcek @gtanzillo please review

https://bugzilla.redhat.com/show_bug.cgi?id=1386331