### PR TITLE
Add Azure SSA rake tasks

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -3,6 +3,8 @@ require 'rspec/core/rake_task'
 require 'rake'
 require 'rake/testtask'
 
+Rake.add_rakelib 'lib/gems/pending/lib/tasks'
+
 RSpec::Core::RakeTask.new(:spec) do |t|
   t.rspec_opts = "--options #{File.expand_path(".rspec_ci", __dir__)}" if ENV['CI']
 end


### PR DESCRIPTION
This adds the SSA related tasks for Azure back into the available rake tasks.