### PR TITLE
Add concurrent jobs parameter to pg_dump and pg_restore for faster exec

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -156,7 +156,7 @@ class PostgresAdmin
 
     opts = opts.dup
     dbname = opts.delete(:dbname)
-    runcmd("pg_dump", opts, :format => "c", :file => opts[:local_file], nil => dbname)
+    runcmd("pg_dump", opts, :format => "c", :jobs => 3, :file => opts[:local_file], nil => dbname)
     opts[:local_file]
   end
 
@@ -203,7 +203,7 @@ class PostgresAdmin
     # An alternative is to use the -a option to only restore the data if there is not a migration/schema change
     recreate_db(opts)
 
-    runcmd("pg_restore", opts, :verbose => nil, :exit_on_error => nil, nil => opts[:local_file])
+    runcmd("pg_restore", opts, :verbose => nil, :exit_on_error => nil, :jobs => 3, nil => opts[:local_file])
     opts[:local_file]
   end
 


### PR DESCRIPTION
Out of the box cloudforms appliances are already a 2x6, but most database are larger (4x8 or greater). We should be able to take advantage of this with our database backups and restores using concurrency.