### PR TITLE
Do not stop and start evmserverd if it was not running.

### DIFF
--- a/lib/gems/pending/appliance_console/logfile_configuration.rb
+++ b/lib/gems/pending/appliance_console/logfile_configuration.rb
@@ -86,9 +86,9 @@ module ApplianceConsole
 
     def activate_new_disk
       return true unless disk
-      stop_evm
+      stop_evm if evm_was_running
       initialize_logfile_disk
-      start_evm
+      start_evm if evm_was_running
       true
     end
 
@@ -103,14 +103,12 @@ module ApplianceConsole
     end
 
     def start_evm
-      return true unless evm_was_running
       say 'Starting EVM'
       LinuxAdmin::Service.new("evmserverd").enable.start
       LinuxAdmin::Service.new("httpd").enable.start
     end
 
     def stop_evm
-      return true unless evm_was_running
       say 'Stopping EVM'
       LinuxAdmin::Service.new("evmserverd").stop
       LinuxAdmin::Service.new("httpd").stop

--- a/spec/appliance_console/logfile_configuration_spec.rb
+++ b/spec/appliance_console/logfile_configuration_spec.rb
@@ -90,47 +90,42 @@ describe ApplianceConsole::LogfileConfiguration do
       EOT
     end
 
-    context "evm was running" do
-      it "stops and starts evm and configures the logfile disk" do
-        subject.new_logrotate_count = 3
-        subject.disk = double(@spec_name, :size => "9999999", :path => "fake disk")
+    it "when evm was running, stops and starts evm and configures the logfile disk" do
+      subject.new_logrotate_count = 3
+      subject.disk = double(@spec_name, :size => "9999999", :path => "fake disk")
 
-        expect(ApplianceConsole::LogicalVolumeManagement)
-          .to receive(:new).and_return(double(@spec_name, :setup => true))
-        expect(File).to receive(:executable?).with("/sbin/restorecon").and_return(true)
-        expect(AwesomeSpawn).to receive(:run!).with('/sbin/restorecon -R -v /var/www/miq/vmdb/log')
-        expect(FileUtils)
-          .to receive(:mkdir_p).with("#{ApplianceConsole::LogfileConfiguration::LOGFILE_DIRECTORY}/apache")
-        expect(LinuxAdmin::Service).to receive(:new).and_return(double(@spec_name, :stop => nil)).twice
-        expect(AwesomeSpawn)
-          .to receive(:run!).with('/usr/sbin/semanage fcontext -a -t httpd_log_t "#{LOGFILE_DIRECTORY.to_path}(/.*)?"')
-        expect(LinuxAdmin::Service)
-          .to receive(:new).and_return(double(@spec_name, :enable => double(@spec_name, :start => true))).twice
-
-        expect(subject.activate).to be true
-        expect(File.read(miq_logs_conf)).to eq(expected_miq_logs_conf)
-      end
+      expect(ApplianceConsole::LogicalVolumeManagement).to receive(:new)
+        .and_return(double(@spec_name, :setup => true))
+      expect(File).to receive(:executable?).with("/sbin/restorecon").and_return(true)
+      expect(AwesomeSpawn).to receive(:run!).with('/sbin/restorecon -R -v /var/www/miq/vmdb/log')
+      expect(FileUtils).to receive(:mkdir_p)
+        .with("#{ApplianceConsole::LogfileConfiguration::LOGFILE_DIRECTORY}/apache")
+      expect(LinuxAdmin::Service).to receive(:new).and_return(double(@spec_name, :stop => nil)).twice
+      expect(AwesomeSpawn).to receive(:run!)
+        .with('/usr/sbin/semanage fcontext -a -t httpd_log_t "#{LOGFILE_DIRECTORY.to_path}(/.*)?"')
+      expect(LinuxAdmin::Service).to receive(:new)
+        .and_return(double(@spec_name, :enable => double(@spec_name, :start => true))).twice
+      expect(subject.activate).to be true
+      expect(File.read(miq_logs_conf)).to eq(expected_miq_logs_conf)
     end
 
-    context "evm was not running" do
-      it "configures the logfile disk but does not stops and starts evm" do
-        subject.evm_was_running = false
-        subject.new_logrotate_count = 3
-        subject.disk = double(@spec_name, :size => "9999999", :path => "fake disk")
+    it "when evm was not running, configures the logfile disk but does not stops and starts evm" do
+      subject.evm_was_running = false
+      subject.new_logrotate_count = 3
+      subject.disk = double(@spec_name, :size => "9999999", :path => "fake disk")
 
-        expect(ApplianceConsole::LogicalVolumeManagement)
-          .to receive(:new).and_return(double(@spec_name, :setup => true))
-        expect(File).to receive(:executable?).with("/sbin/restorecon").and_return(true)
-        expect(AwesomeSpawn).to receive(:run!).with('/sbin/restorecon -R -v /var/www/miq/vmdb/log')
-        expect(FileUtils)
-          .to receive(:mkdir_p).with("#{ApplianceConsole::LogfileConfiguration::LOGFILE_DIRECTORY}/apache")
-        expect(AwesomeSpawn)
-          .to receive(:run!).with('/usr/sbin/semanage fcontext -a -t httpd_log_t "#{LOGFILE_DIRECTORY.to_path}(/.*)?"')
-        expect(LinuxAdmin::Service).to_not receive(:new)
+      expect(ApplianceConsole::LogicalVolumeManagement).to receive(:new)
+        .and_return(double(@spec_name, :setup => true))
+      expect(File).to receive(:executable?).with("/sbin/restorecon").and_return(true)
+      expect(AwesomeSpawn).to receive(:run!).with('/sbin/restorecon -R -v /var/www/miq/vmdb/log')
+      expect(FileUtils).to receive(:mkdir_p)
+        .with("#{ApplianceConsole::LogfileConfiguration::LOGFILE_DIRECTORY}/apache")
+      expect(AwesomeSpawn).to receive(:run!)
+        .with('/usr/sbin/semanage fcontext -a -t httpd_log_t "#{LOGFILE_DIRECTORY.to_path}(/.*)?"')
+      expect(LinuxAdmin::Service).to_not receive(:new)
 
-        expect(subject.activate).to be true
-        expect(File.read(miq_logs_conf)).to eq(expected_miq_logs_conf)
-      end
+      expect(subject.activate).to be true
+      expect(File.read(miq_logs_conf)).to eq(expected_miq_logs_conf)
     end
   end
 end

--- a/spec/appliance_console/logfile_configuration_spec.rb
+++ b/spec/appliance_console/logfile_configuration_spec.rb
@@ -94,17 +94,19 @@ describe ApplianceConsole::LogfileConfiguration do
       it "stops and starts evm and configures the logfile disk" do
         subject.new_logrotate_count = 3
         subject.disk = double(@spec_name, :size => "9999999", :path => "fake disk")
-  
-        expect(ApplianceConsole::LogicalVolumeManagement).to receive(:new).and_return(double(@spec_name, :setup => true))
+
+        expect(ApplianceConsole::LogicalVolumeManagement)
+          .to receive(:new).and_return(double(@spec_name, :setup => true))
         expect(File).to receive(:executable?).with("/sbin/restorecon").and_return(true)
         expect(AwesomeSpawn).to receive(:run!).with('/sbin/restorecon -R -v /var/www/miq/vmdb/log')
-        expect(FileUtils).to receive(:mkdir_p).with("#{ApplianceConsole::LogfileConfiguration::LOGFILE_DIRECTORY}/apache")
+        expect(FileUtils)
+          .to receive(:mkdir_p).with("#{ApplianceConsole::LogfileConfiguration::LOGFILE_DIRECTORY}/apache")
         expect(LinuxAdmin::Service).to receive(:new).and_return(double(@spec_name, :stop => nil)).twice
         expect(AwesomeSpawn)
           .to receive(:run!).with('/usr/sbin/semanage fcontext -a -t httpd_log_t "#{LOGFILE_DIRECTORY.to_path}(/.*)?"')
         expect(LinuxAdmin::Service)
           .to receive(:new).and_return(double(@spec_name, :enable => double(@spec_name, :start => true))).twice
-  
+
         expect(subject.activate).to be true
         expect(File.read(miq_logs_conf)).to eq(expected_miq_logs_conf)
       end
@@ -115,15 +117,17 @@ describe ApplianceConsole::LogfileConfiguration do
         subject.evm_was_running = false
         subject.new_logrotate_count = 3
         subject.disk = double(@spec_name, :size => "9999999", :path => "fake disk")
-  
-        expect(ApplianceConsole::LogicalVolumeManagement).to receive(:new).and_return(double(@spec_name, :setup => true))
+
+        expect(ApplianceConsole::LogicalVolumeManagement)
+          .to receive(:new).and_return(double(@spec_name, :setup => true))
         expect(File).to receive(:executable?).with("/sbin/restorecon").and_return(true)
         expect(AwesomeSpawn).to receive(:run!).with('/sbin/restorecon -R -v /var/www/miq/vmdb/log')
-        expect(FileUtils).to receive(:mkdir_p).with("#{ApplianceConsole::LogfileConfiguration::LOGFILE_DIRECTORY}/apache")
+        expect(FileUtils)
+          .to receive(:mkdir_p).with("#{ApplianceConsole::LogfileConfiguration::LOGFILE_DIRECTORY}/apache")
         expect(AwesomeSpawn)
           .to receive(:run!).with('/usr/sbin/semanage fcontext -a -t httpd_log_t "#{LOGFILE_DIRECTORY.to_path}(/.*)?"')
         expect(LinuxAdmin::Service).to_not receive(:new)
-  
+
         expect(subject.activate).to be true
         expect(File.read(miq_logs_conf)).to eq(expected_miq_logs_conf)
       end


### PR DESCRIPTION
This PR simply ensures the evmserverd service is not manipulated after logfile
configuration changes are made, if the evmserverd service was not running.

**To test this upstream:**

- add an extra harddisk to the test appliance,
- disable evmserverd
- attempt to use the appliance_console to add a new logfile disk volume.

To disable the evmserverd service upstream do:

```
  systemctl stop evmserverd && systemctl disable evmserverd
  systemctl stop $APPLIANCE_PG_SERVICE && systemctl disable $APPLIANCE_PG_SERVICE
  echo "rm PG data"
  rm -rf $APPLIANCE_PG_DATA/*
  vmdb
  rm -f REGION config/database.yml GUID
```

After executing the above commands use the appliance_console to configure a new
logfile disk volume, ensuring no traceback is produced. 

https://bugzilla.redhat.com/show_bug.cgi?id=1393349