### PR TITLE
Corrected prompt for External Authentication Options menu in appliance console

### DIFF
--- a/lib/gems/pending/appliance_console/external_auth_options.rb
+++ b/lib/gems/pending/appliance_console/external_auth_options.rb
@@ -32,7 +32,7 @@ module ApplianceConsole
       skip = apply + 1
       selection = 0
       while selection < apply
-        say("\nChoose External Authentication Options to update:")
+        say("\nExternal Authentication Options:")
         cnt = 1
         EXT_AUTH_OPTIONS.keys.each do |key|
           current_state = selected_value(key)
@@ -42,7 +42,7 @@ module ApplianceConsole
         say("#{apply}) Apply updates")
         say("#{skip}) Skip updates")
         show_updates
-        selection = ask_for_integer("Choose option 1-#{skip}", 1..skip)
+        selection = ask_for_integer("option number to apply", 1..skip)
         if selection < apply
           key = EXT_AUTH_OPTIONS.keys[selection - 1]
           @updates[key] = !selected_value(key)


### PR DESCRIPTION
Corrected prompt for External Authentication Options menu in appliance console

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1412043

BEFORE:
![before](https://cloud.githubusercontent.com/assets/6556758/21950945/e9fc5bce-d9cd-11e6-83d2-2bbb5290faf5.png)

AFTER:
<img width="562" alt="after" src="https://cloud.githubusercontent.com/assets/6556758/21996823/04cbc5b0-dbfa-11e6-8d5e-9984cb7a2f8e.png">



@miq-bot add-label core
