### PR TITLE
Apply Selection Spec to `hostSystemsStorageDevice`

### DIFF
--- a/lib/gems/pending/VMwareWebService/MiqVimInventory.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimInventory.rb
@@ -1352,8 +1352,13 @@ class MiqVimInventory < MiqVimClientBase
   end
 
   def hostSystemsStorageDevice(hostMors, selSpec = nil)
-    sd = getMoPropMulti(hostMors, "config.storageDevice")
-    sd = applySelector(sd, selSpec) if selSpec
+    if selSpec.nil?
+      sd = getMoPropMulti(hostMors, "config.storageDevice")
+    else
+      pp = selSpecToPropPath(selSpec)
+      sd = getMoPropMulti(hostMors, pp)
+      sd = applySelector(sd, selSpec)
+    end
 
     sd
   end
@@ -2356,7 +2361,9 @@ class MiqVimInventory < MiqVimClientBase
   end
 
   def ss2pp(ss)
-    getSelSpec(ss).collect { |s| s.split("[")[0] }.uniq
+    # We add "MOR" it isn't from VMware so always strip it out of
+    # the propPath even if it is in the selSpec
+    getSelSpec(ss).collect { |s| s.split("[")[0] }.uniq - ["MOR"]
   end
   private :ss2pp
 


### PR DESCRIPTION
Use the provided selection spec to filter the properties returned by the VC.  The selection spec was being applied to the result but not to the propPath before the call.

This was already done in MiqVimHost in https://github.com/ManageIQ/manageiq-gems-pending/blob/master/lib/gems/pending/VMwareWebService/MiqVimHost.rb#L267 but didn't get moved over to `MiqVimInventory`

This should reduce the size of the payload returned by excluding `config.storageDevice.multipathInfo`, `config.storageDevice.plugStoreTopology`, and `config.storageDevice.softwareInternetScsiEnabled`