### PR TITLE
Add RewriteCond to disable rewrite to index of css and js files 

### DIFF
--- a/lib/gems/pending/util/miq_apache/miq_apache.rb
+++ b/lib/gems/pending/util/miq_apache/miq_apache.rb
@@ -206,7 +206,8 @@ module MiqApache
     def self.create_redirects_config(opts = {})
       opts[:redirects].to_miq_a.each_with_object("") do |redirect, content|
         if redirect == "/"
-          content << "RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext)) /ui/service/index.html [L]\n"
+          content << "RewriteCond %{REQUEST_URI} !(\.css|\.js)$ [NC]\n"
+          content << "RewriteRule ^/ui/service(?!/(assets|data|images|img|styles|js|fonts|vendor|gettext)) /ui/service/index.html [L]\n"
           content << "RewriteCond \%{REQUEST_URI} !^/ws\n"
           content << "RewriteCond \%{REQUEST_URI} !^/proxy_pages\n"
           content << "RewriteCond \%{REQUEST_URI} !^/saml2\n"


### PR DESCRIPTION
Add RewriteCond to disable rewrite to index of css and js files in thee self service ui and make the ui work again.

At the moment the self service ui in the nightly appliance does not work and shows a blank site. there is an issue with the rewriterules in the apache config, which rewrites the css and js assets to index.html.

Also do not rewrite the `data` dir, which is used by the css.