### PR TITLE
Miq password decrypt with an alternate key

### DIFF
--- a/lib/gems/pending/util/miq-password.rb
+++ b/lib/gems/pending/util/miq-password.rb
@@ -24,20 +24,18 @@ class MiqPassword
   end
 
   def decrypt(str, legacy = false)
-    if str.nil? || str.empty?
-      str
-    else
-      ver, enc = self.class.split(str)
-      return "" if enc.empty?
+    return str if str.nil? || str.empty?
 
-      ver ||= "0" # if we don't know what it is, just assume legacy
-      key_name = (ver == "2" && legacy) ? "alt" : "v#{ver}"
+    ver, enc = self.class.split(str)
+    return "" if enc.empty?
 
-      begin
-        self.class.keys[key_name].decrypt64(enc).force_encoding('UTF-8')
-      rescue
-        raise MiqPasswordError, "can not decrypt v#{ver}_key encrypted string"
-      end
+    ver ||= "0" # if we don't know what it is, just assume legacy
+    key_name = (ver == "2" && legacy) ? "alt" : "v#{ver}"
+
+    begin
+      self.class.keys[key_name].decrypt64(enc).force_encoding('UTF-8')
+    rescue
+      raise MiqPasswordError, "can not decrypt v#{ver}_key encrypted string"
     end
   end
 

--- a/lib/gems/pending/util/miq-password.rb
+++ b/lib/gems/pending/util/miq-password.rb
@@ -23,17 +23,21 @@ class MiqPassword
     "#{ver}:{#{value}}"
   end
 
-  def decrypt(str, legacy = false)
+  def decrypt(str, legacy = false, key = nil)
     return str if str.nil? || str.empty?
 
     ver, enc = self.class.split(str)
     return "" if enc.empty?
 
     ver ||= "0" # if we don't know what it is, just assume legacy
-    key_name = (ver == "2" && legacy) ? "alt" : "v#{ver}"
+
+    key ||= begin
+      key_name = (ver == "2" && legacy) ? "alt" : "v#{ver}"
+      self.class.keys[key_name]
+    end
 
     begin
-      self.class.keys[key_name].decrypt64(enc).force_encoding('UTF-8')
+      key.decrypt64(enc).force_encoding('UTF-8')
     rescue
       raise MiqPasswordError, "can not decrypt v#{ver}_key encrypted string"
     end

--- a/spec/util/miq-password_spec.rb
+++ b/spec/util/miq-password_spec.rb
@@ -321,6 +321,17 @@ describe MiqPassword do
     end
   end
 
+  it "#encrypt / #decrypt with a random key" do
+    string = "test"
+    string_encrypted = "v2:{X/vcdbizCnNs+djHfPrPwg==}"
+    with_alternate_key do |key|
+      expect(MiqPassword.new.encrypt(string, "v2", key)).to eq(string_encrypted)
+      expect(MiqPassword.new.decrypt(string_encrypted, false, key)).to eq(string)
+      expect(MiqPassword.encrypt(string)).not_to eq(string_encrypted)
+      expect { MiqPassword.decrypt(string_encrypted) }.to raise_error("can not decrypt v2_key encrypted string")
+    end
+  end
+
   describe "#recrypt" do
     context "#with ambigious keys" do
       let(:old_key) { EzCrypto::Key.decode("JZjTdiuOzWlTHUkBZSGj9BmWEoswxvImWuwD/xN87s0=", :algorithm => "aes-256-cbc") }
@@ -364,5 +375,23 @@ describe MiqPassword do
 
   def erberize(password, passmethod = "MiqPassword")
     "<%= #{passmethod}.decrypt(\"#{password}\") %>"
+  end
+
+  def with_alternate_key
+    random_key = <<EOK
+---
+:EZCRYPTO KEY FILE: KEEP THIS SECURE !
+:created: 2014-02-28 09:59:47 -0500
+:algorithm: aes-256-cbc
+:key: YWJjYWJjYWJjYWJjYWJjYWJjYWJjYmFiY2JhY2JhYgz=
+EOK
+    file = Tempfile.new("random_key")
+    begin
+      file.write(random_key)
+      file.close
+      yield(EzCrypto::Key.load(file.path))
+    ensure
+      file.unlink
+    end
   end
 end


### PR DESCRIPTION
Allow MiqPassword#decrypt to also use an alternate key.
https://bugzilla.redhat.com/show_bug.cgi?id=1400995