### PR TITLE
Do not configure ext auth if http is not configured.

### DIFF
--- a/lib/gems/pending/appliance_console/external_httpd_authentication.rb
+++ b/lib/gems/pending/appliance_console/external_httpd_authentication.rb
@@ -79,11 +79,12 @@ module ApplianceConsole
     end
 
     def post_activation
-      say("\nRestarting sssd and httpd ...")
-      %w(sssd httpd).each { |service| LinuxAdmin::Service.new(service).restart }
+      say("\nRestarting httpd, if running ...")
+      httpd_service = LinuxAdmin::Service.new("httpd")
+      httpd_service.restart if httpd_service.running?
 
-      say("Configuring sssd to start upon reboots ...")
-      LinuxAdmin::Service.new("sssd").enable
+      say("Restarting sssd and configure it to start on reboots ...")
+      LinuxAdmin::Service.new("sssd").restart.enable
     end
 
     private


### PR DESCRIPTION
This PR simply ensures attempts to configure external authentication are
abandoned if the manageiq http configuration files have not yet been
created.

### To test this upstream:

disable evmserverd
attempt to use the appliance_console to configure external authentication.
ensure not traceback is produced

### To disable the evmserverd service upstream do:

```
  systemctl stop evmserverd && systemctl disable evmserverd
  systemctl stop $APPLIANCE_PG_SERVICE && systemctl disable $APPLIANCE_PG_SERVICE
  echo "rm PG data"
  rm -rf $APPLIANCE_PG_DATA/*
  vmdb
  rm -f REGION config/database.yml GUID
  rm /etc/httpd/conf.d/manageiq*

```

After executing the above commands attempt to use the appliance_console to
configure external authentication, ensuring no traceback is produced.

https://bugzilla.redhat.com/show_bug.cgi?id=1396184