### PR TITLE
Prerequisites for running ansible inside the appliance

### DIFF
--- a/lib/gems/pending/appliance_console/database_configuration.rb
+++ b/lib/gems/pending/appliance_console/database_configuration.rb
@@ -150,10 +150,10 @@ FRIENDLY
     def settings_hash
       {
         'adapter'  => 'postgresql',
-        'host'     => local? ? nil : host,
-        'port'     => local? ? nil : port,
+        'host'     => local? ? "localhost" : host,
+        'port'     => port,
         'username' => username,
-        'password' => local? ? nil : password.presence,
+        'password' => password.presence,
         'database' => database
       }
     end

--- a/lib/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/internal_database_configuration.rb
@@ -136,11 +136,13 @@ module ApplianceConsole
       conn = PG.connect(:user => "postgres", :dbname => "postgres")
       esc_pass = conn.escape_string(password)
       conn.exec("CREATE ROLE #{username} WITH LOGIN CREATEDB SUPERUSER PASSWORD '#{esc_pass}'")
+      conn.exec("CREATE ROLE awx WITH LOGIN PASSWORD '#{esc_pass}'")
     end
 
     def create_postgres_database
       conn = PG.connect(:user => "postgres", :dbname => "postgres")
       conn.exec("CREATE DATABASE #{database} OWNER #{username} ENCODING 'utf8'")
+      conn.exec("CREATE DATABASE awx OWNER awx ENCODING 'utf8'")
     end
 
     def relabel_postgresql_dir

--- a/spec/appliance_console/database_configuration_spec.rb
+++ b/spec/appliance_console/database_configuration_spec.rb
@@ -323,12 +323,6 @@ describe ApplianceConsole::DatabaseConfiguration do
     context "#merged_settings" do
       subject { @config.merged_settings["production"] }
 
-      it "should remove host/password from previous values for localhost" do
-        @config.host = "localhost"
-        @config.port = "123"
-        expect(subject).not_to include("host", "port", "password")
-      end
-
       it "should inherit unchanged non-core values" do
         expect(subject).to include("encoding" => "utf8", "pools" => "5")
       end


### PR DESCRIPTION
This PR creates the postgres database that will be used for ansible on the appliance when we create our database.

Additionally this PR adds the host and password to `database.yml` even when we are running a database locally. This was done so that the password is accessible at configuration time to provide to the ansible process so that it can contact the database.

https://www.pivotaltracker.com/story/show/137048481