### PR TITLE
Add MiqNetworkPortNotDefinedError

### DIFF
--- a/lib/gems/pending/util/miq-exception.rb
+++ b/lib/gems/pending/util/miq-exception.rb
@@ -127,6 +127,8 @@ module MiqException
   class MiqNetworkRouterAddInterfaceError < Error; end
   class MiqNetworkRouterRemoveInterfaceError < Error; end
 
+  class MiqNetworkPortNotDefinedError < Error; end
+
   class MiqVolumeValidationError < Error; end
   class MiqVolumeCreateError < Error; end
   class MiqVolumeUpdateError < Error; end


### PR DESCRIPTION
Adds a new exception used by https://github.com/ManageIQ/manageiq/pull/13608