### PR TITLE
Do not show traceback when looking for OSP service

### DIFF
--- a/lib/gems/pending/openstack/openstack_handle/handle.rb
+++ b/lib/gems/pending/openstack/openstack_handle/handle.rb
@@ -87,7 +87,6 @@ module OpenstackHandle
       $fog_log.warn("MIQ(#{self.class.name}##{__method__}) "\
                     "Service #{service} not available for openstack provider #{auth_url}")
       $fog_log.warn(err.message)
-      $fog_log.warn(err.backtrace.join("\n"))
       raise MiqException::ServiceNotAvailable if err.message.include?("Could not find service")
       raise
     end


### PR DESCRIPTION
The traceback for this situation looks an awful like like an error:

```
[----] W, [2017-01-24T16:30:15.053981 #28117:104f12c]  WARN -- : MIQ(Class#raw_connect) Service NFV not available for openstack provider http://0.0.0.0:5000/v2.0/tokens
[----] W, [2017-01-24T16:30:15.054091 #28117:104f12c]  WARN -- : Could not find service nfv-orchestration.  Have alarming, cloudformation, compute, identity, image, metering, metric, network, object-store, orchestration, volume, volumev2, volumev3
[----] W, [2017-01-24T16:30:15.054308 #28117:104f12c]  WARN -- : /opt/rh/cfme-gemset/gems/fog-openstack-0.1.17/lib/fog/openstack.rb:215:in `authenticate_v2'
/opt/rh/cfme-gemset/gems/fog-openstack-0.1.17/lib/fog/openstack.rb:135:in `authenticate'
/opt/rh/cfme-gemset/gems/fog-openstack-0.1.17/lib/fog/openstack/core.rb:139:in `authenticate'
/opt/rh/cfme-gemset/gems/fog-openstack-0.1.17/lib/fog/nfv/openstack.rb:113:in `initialize'
/opt/rh/cfme-gemset/gems/fog-core-1.43.0/lib/fog/core/service.rb:115:in `new'
/opt/rh/cfme-gemset/gems/fog-core-1.43.0/lib/fog/core/service.rb:115:in `new'
/opt/rh/cfme-gemset/gems/fog-core-1.43.0/lib/fog/core/services_mixin.rb:16:in `new'
/var/www/miq/vmdb/gems/pending/openstack/openstack_handle/handle.rb:84:in `raw_connect'
/var/www/miq/vmdb/gems/pending/openstack/openstack_handle/handle.rb:53:in `block in raw_connect_try_ssl'
/var/www/miq/vmdb/gems/pending/openstack/openstack_handle/handle.rb:43:in `try_connection'
/var/www/miq/vmdb/gems/pending/openstack/openstack_handle/handle.rb:50:in `raw_connect_try_ssl'
/var/www/miq/vmdb/gems/pending/openstack/openstack_handle/handle.rb:185:in `connect'
/var/www/miq/vmdb/gems/pending/openstack/openstack_handle/handle.rb:316:in `detect_service'
/var/www/miq/vmdb/gems/pending/openstack/openstack_handle/handle.rb:247:in `detect_nfv_service'
/var/www/miq/vmdb/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb:29:in `initialize'
/var/www/miq/vmdb/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb:13:in `new'
/var/www/miq/vmdb/app/models/manageiq/providers/openstack/cloud_manager/refresh_parser.rb:13:in `ems_inv_to_hashes'
/var/www/miq/vmdb/app/models/manageiq/providers/openstack/cloud_manager/refresher.rb:6:in `parse_legacy_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:122:in `block in parse_targeted_inventory'
/var/www/miq/vmdb/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/var/www/miq/vmdb/gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'
/var/www/miq/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:122:in `parse_targeted_inventory'
/var/www/miq/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:87:in `block in refresh_targets_for_ems'
/var/www/miq/vmdb/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/var/www/miq/vmdb/gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'
/var/www/miq/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:86:in `refresh_targets_for_ems'
/var/www/miq/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:24:in `block (2 levels) in refresh'
/var/www/miq/vmdb/gems/pending/util/extensions/miq-benchmark.rb:11:in `realtime_store'
/var/www/miq/vmdb/gems/pending/util/extensions/miq-benchmark.rb:30:in `realtime_block'
/var/www/miq/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:24:in `block in refresh'
/var/www/miq/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:14:in `each'
/var/www/miq/vmdb/app/models/ems_refresh/refreshers/ems_refresher_mixin.rb:14:in `refresh'
/var/www/miq/vmdb/app/models/manageiq/providers/base_manager/refresher.rb:10:in `refresh'
/var/www/miq/vmdb/app/models/ems_refresh.rb:91:in `block in refresh'
/var/www/miq/vmdb/app/models/ems_refresh.rb:90:in `each'
/var/www/miq/vmdb/app/models/ems_refresh.rb:90:in `refresh'
/var/www/miq/vmdb/app/models/miq_queue.rb:347:in `block in deliver'
/opt/rh/rh-ruby23/root/usr/share/ruby/timeout.rb:91:in `block in timeout'
/opt/rh/rh-ruby23/root/usr/share/ruby/timeout.rb:33:in `block in catch'
/opt/rh/rh-ruby23/root/usr/share/ruby/timeout.
```

By removing the traceback, we'll continue to show the warning without making the user feel like something blew up.