### PR TITLE
Remove the awx database creation

### DIFF
--- a/lib/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/internal_database_configuration.rb
@@ -136,13 +136,11 @@ module ApplianceConsole
       conn = PG.connect(:user => "postgres", :dbname => "postgres")
       esc_pass = conn.escape_string(password)
       conn.exec("CREATE ROLE #{username} WITH LOGIN CREATEDB SUPERUSER PASSWORD '#{esc_pass}'")
-      conn.exec("CREATE ROLE awx WITH LOGIN PASSWORD '#{esc_pass}'")
     end
 
     def create_postgres_database
       conn = PG.connect(:user => "postgres", :dbname => "postgres")
       conn.exec("CREATE DATABASE #{database} OWNER #{username} ENCODING 'utf8'")
-      conn.exec("CREATE DATABASE awx OWNER awx ENCODING 'utf8'")
     end
 
     def relabel_postgresql_dir


### PR DESCRIPTION
This will be done when the ansible role is started from within the app itself.

This approach allows us to generate a new password rather than using the same one as our superuser. We want to do this because ansible stores its database password in plain-text on the filesystem.

Moving this functionality into https://github.com/ManageIQ/manageiq/pull/13584