### PR TITLE
Fix ruby 2.2 test failure on Tempfile.new without args

### DIFF
--- a/spec/appliance_console/database_maintenance_periodic_spec.rb
+++ b/spec/appliance_console/database_maintenance_periodic_spec.rb
@@ -2,15 +2,15 @@ require "appliance_console/database_maintenance_periodic"
 
 describe ApplianceConsole::DatabaseMaintenancePeriodic do
   before do
-    @test_crontab_1 = Tempfile.new("crontab")
-    stub_const("ApplianceConsole::DatabaseMaintenancePeriodic::CRONTAB_FILE", @test_crontab_1.path)
+    @test_crontab1 = Tempfile.new("crontab")
+    stub_const("ApplianceConsole::DatabaseMaintenancePeriodic::CRONTAB_FILE", @test_crontab1.path)
     allow(subject).to receive(:say)
     allow(subject).to receive(:clear_screen)
     allow(subject).to receive(:agree)
   end
 
   after do
-    FileUtils.rm_f(@test_crontab_1.path)
+    FileUtils.rm_f(@test_crontab1.path)
   end
 
   describe "#confirm" do

--- a/spec/appliance_console/database_maintenance_periodic_spec.rb
+++ b/spec/appliance_console/database_maintenance_periodic_spec.rb
@@ -2,7 +2,7 @@ require "appliance_console/database_maintenance_periodic"
 
 describe ApplianceConsole::DatabaseMaintenancePeriodic do
   before do
-    @test_crontab_1 = Tempfile.new
+    @test_crontab_1 = Tempfile.new("crontab")
     stub_const("ApplianceConsole::DatabaseMaintenancePeriodic::CRONTAB_FILE", @test_crontab_1.path)
     allow(subject).to receive(:say)
     allow(subject).to receive(:clear_screen)


### PR DESCRIPTION
```
Failure/Error: @test_crontab_1 = Tempfile.new

    ArgumentError:
      wrong number of arguments (0 for 1..2)
```

The basename arg was required in 2.2:
http://ruby-doc.org/stdlib-2.2.5/libdoc/tempfile/rdoc/Tempfile.html#method-c-new
and became optional later:
http://ruby-doc.org/stdlib-2.4.0/libdoc/tempfile/rdoc/Tempfile.html#method-c-new
2.3 still documents it as required but de-facto works if omitted, which is why it failed for me locally, but passed on Travis.