### PR TITLE
Fixed typo in appliance console when configuring a database

### DIFF
--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -149,7 +149,7 @@ module ApplianceConsole
 
       if verify && disk.nil?
         say ""
-        raise MiqSignalError unless are_you_sure?(" you don't want to partion the #{disk_name}")
+        raise MiqSignalError unless are_you_sure?(" you don't want to partition the #{disk_name}")
       end
       disk
     end

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -254,7 +254,7 @@ describe ApplianceConsole::Prompts do
         expect_heard [
           "No partition found for database disk. You probably want to add an unpartitioned disk and try again.",
           "",
-          "Are you sure you don't want to partion the database disk? (Y/N): ",
+          "Are you sure you don't want to partition the database disk? (Y/N): ",
         ]
       end
 
@@ -264,7 +264,7 @@ describe ApplianceConsole::Prompts do
         expect_heard [
           "No partition found for special disk. You probably want to add an unpartitioned disk and try again.",
           "",
-          "Are you sure you don't want to partion the special disk? (Y/N): ",
+          "Are you sure you don't want to partition the special disk? (Y/N): ",
         ]
       end
 


### PR DESCRIPTION
Fixed typo in ```prompts.rb```:  'partion' to 'partition'

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1414672

AFTER:
![after](https://cloud.githubusercontent.com/assets/6556758/22341015/58e0d6b6-e3bd-11e6-8f24-f50ef94f456c.png)

@miq-bot add-label bug
