### PR TITLE
Add a RewriteCond for `/ansibleapi`

### DIFF
--- a/lib/gems/pending/util/miq_apache/miq_apache.rb
+++ b/lib/gems/pending/util/miq_apache/miq_apache.rb
@@ -211,6 +211,7 @@ module MiqApache
           content << "RewriteCond \%{REQUEST_URI} !^/proxy_pages\n"
           content << "RewriteCond \%{REQUEST_URI} !^/saml2\n"
           content << "RewriteCond \%{REQUEST_URI} !^/api\n"
+          content << "RewriteCond \%{REQUEST_URI} !^/ansibleapi\n"
           content << "RewriteCond \%{DOCUMENT_ROOT}/\%{REQUEST_FILENAME} !-f\n"
           content << "RewriteRule ^#{redirect} balancer://#{opts[:cluster]}\%{REQUEST_URI} [P,QSA,L]\n"
         else


### PR DESCRIPTION
This will ensure that requests starting with `/ansibleapi` are not routed to our UI.

https://www.pivotaltracker.com/story/show/135450659