### PR TITLE
Add a redirect from the old /self_service to the new /ui/service

### DIFF
--- a/lib/gems/pending/util/miq_apache/miq_apache.rb
+++ b/lib/gems/pending/util/miq_apache/miq_apache.rb
@@ -207,6 +207,7 @@ module MiqApache
       opts[:redirects].to_miq_a.each_with_object("") do |redirect, content|
         if redirect == "/"
           content << "RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext)) /ui/service/index.html [L]\n"
+          content << "RewriteRule ^/self_service(.*) /ui/service$1 [R]\n"
           content << "RewriteCond \%{REQUEST_URI} !^/ws\n"
           content << "RewriteCond \%{REQUEST_URI} !^/proxy_pages\n"
           content << "RewriteCond \%{REQUEST_URI} !^/saml2\n"

--- a/spec/util/miq_apache/conf_spec.rb
+++ b/spec/util/miq_apache/conf_spec.rb
@@ -41,6 +41,7 @@ describe MiqApache::Conf do
       default_options = {:cluster => 'evmcluster_ui', :redirects => %w(/)}
       output = MiqApache::Conf.create_redirects_config(default_options).lines.to_a
       expect(output).to include("RewriteRule ^/ui/service(?!/(assets|images|img|styles|js|fonts|vendor|gettext)) /ui/service/index.html [L]\n")
+      expect(output).to include("RewriteRule ^/self_service(.*) /ui/service$1 [R]\n")
       expect(output).to include("RewriteCond \%{REQUEST_URI} !^/proxy_pages\n")
       expect(output).to include("RewriteCond \%{REQUEST_URI} !^/saml2\n")
       expect(output).to include("RewriteCond \%{DOCUMENT_ROOT}/\%{REQUEST_FILENAME} !-f\n")


### PR DESCRIPTION
This should be considered deprecated and should be removed for the next release.

https://bugzilla.redhat.com/show_bug.cgi?id=1410748