### PR TITLE
MiqContainerGroup, WebDAV: take net/http options hash

### DIFF
--- a/lib/gems/pending/MiqContainerGroup/MiqContainerGroup.rb
+++ b/lib/gems/pending/MiqContainerGroup/MiqContainerGroup.rb
@@ -1,21 +1,30 @@
 require 'fs/MiqFS/modules/WebDAV'
 
 class MiqContainerGroup
-  attr_reader :uri, :verify_mode, :headers, :guest_os
+  attr_reader :uri, :http_options, :headers, :guest_os
 
-  def initialize(uri, verify_mode, headers, guest_os)
-    @uri         = uri
-    @verify_mode = verify_mode
-    @headers     = headers
-    @guest_os    = guest_os
+  # http_options are in Net::HTTP format.
+  def initialize(uri, http_options, headers, guest_os)
+    @uri = uri
+    unless http_options.kind_of?(Hash)
+      # backward compatibility, 2nd param used to be verify_mode
+      http_options = {:verify_mode => http_options}
+    end
+    @http_options = {:use_ssl => URI(uri).scheme == 'https'}.merge(http_options)
+    @headers      = headers
+    @guest_os     = guest_os
+  end
+
+  def verify_mode
+    http_options[:verify_mode]
   end
 
   def rootTrees
     web_dav_ost = OpenStruct.new(
-      :uri         => @uri,
-      :verify_mode => @verify_mode,
-      :headers     => @headers,
-      :guest_os    => @guest_os
+      :uri          => @uri,
+      :http_options => @http_options,
+      :headers      => @headers,
+      :guest_os     => @guest_os
     )
     [MiqFS.new(WebDAV, web_dav_ost)]
   end

--- a/lib/gems/pending/fs/MiqFS/modules/WebDAV.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/WebDAV.rb
@@ -16,8 +16,7 @@ module WebDAV
     @connection = Net::HTTP.start(
       @uri.host,
       @uri.port,
-      :use_ssl     => @uri.scheme == 'https',
-      :verify_mode => @dobj.verify_mode || OpenSSL::SSL::VERIFY_PEER
+      @dobj.http_options
     )
   end
 
@@ -89,7 +88,7 @@ module WebDAV
 
   def fs_fileOpen(path, mode = "r")
     raise Errno::EACCES unless mode == 'r'
-    WebDAVFile.new(remote_uri(path), @connection.verify_mode, @headers)
+    WebDAVFile.new(remote_uri(path), @dobj.http_options, @headers)
   end
 
   def fs_fileSeek(fobj, offset, whence)

--- a/lib/gems/pending/fs/MiqFS/modules/WebDAVFile.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/WebDAVFile.rb
@@ -1,15 +1,14 @@
 require 'net/http'
 
 class WebDAVFile
-  def initialize(uri, verify_mode, headers)
+  def initialize(uri, http_options, headers)
     @uri = uri
     @headers = headers
     @offset = 0
     @connection = Net::HTTP.start(
       @uri.host,
       @uri.port,
-      :use_ssl     => @uri.scheme == 'https',
-      :verify_mode => verify_mode
+      http_options
     )
   end
 


### PR DESCRIPTION
I need to pass more http options to MiqContainerGroup from manageiq.

- Kept backward compatibility for MiqContainerGroup constructor &
  verify_mode accessor, so this should be mergable before modifying
  ManageIQ to use new interface.

- WebDAV & WebDAVFile interface is NOT backward-compatible.
  AFAICT nothing in ManageIQ depends on them directly.

This repo seems to have zero tests for these 3 classes :-(
@simon3z Please advise, should I add tests here? What should they cover?

To be on the safe side, tested other repos locally against this change:

- [x] core manageiq uses MiqContainerGroup, has one relevant test — everything passed.
- [x] manageiq-content (doesn't use MiqFS at all) — failed exacly same 18 failures as [on master](https://travis-ci.org/ManageIQ/manageiq-content/builds/196754973)
- [x] manageiq-providers-amazon (doesn't use ~~MiqFS~~ WebDAV at all?) — everything passed.
- [x] manageiq-providers-azure (doesn't use ~~MiqFS~~ WebDAV at all?) — everything passed.
- [x] manageiq-providers-vmware (doesn't use ~~MiqFS~~ WebDAV at all?) — everything passed.
- [x] manageiq-ui-classic (doesn't use MiqFS at all) — everything passed.

EDIT: obviously core & providers do use MiqFS, just not by 'MiqFS' name, mostly via `MiqVm` and `VMwareWebService`.