### PR TITLE
Start/Stop/Status server  option

### DIFF
--- a/lib/gems/pending/appliance_console/cli.rb
+++ b/lib/gems/pending/appliance_console/cli.rb
@@ -83,6 +83,10 @@ module ApplianceConsole
       options[:extauth_opts]
     end
 
+    def set_server_state?
+      options[:server]
+    end
+
     def initialize(options = {})
       self.options = options
     end
@@ -134,6 +138,7 @@ module ApplianceConsole
         opt :postgres_server_cert, "install certs for postgres server", :type => :boolean
         opt :http_cert,            "install certs for http server",     :type => :boolean
         opt :extauth_opts,         "External Authentication Options",   :type => :string
+        opt :server,               "Server status",                     :type => :string
       end
       Trollop.die :region, "needed when setting up a local database" if options[:region].nil? && local_database?
       self
@@ -141,7 +146,8 @@ module ApplianceConsole
 
     def run
       Trollop.educate unless set_host? || key? || database? || tmp_disk? || log_disk? ||
-                             uninstall_ipa? || install_ipa? || certs? || extauth_opts? || time_zone?
+                             uninstall_ipa? || install_ipa? || certs? || extauth_opts? ||
+                             time_zone? || set_server_state?
       if set_host?
         system_hosts = LinuxAdmin::Hosts.new
         system_hosts.hostname = options[:host]
@@ -158,6 +164,7 @@ module ApplianceConsole
       install_ipa if install_ipa?
       install_certs if certs?
       extauth_opts if extauth_opts?
+      set_server_state if set_server_state?
     rescue AwesomeSpawn::CommandResultError => e
       say e.result.output
       say e.result.error
@@ -320,6 +327,21 @@ module ApplianceConsole
       extauthopts_hash = extauthopts.parse(options[:extauth_opts])
       raise "Must specify at least one external authentication option to set" unless extauthopts_hash.present?
       extauthopts.update_configuration(extauthopts_hash)
+    end
+
+    def set_server_state
+      service = LinuxAdmin::Service.new("evmserverd")
+      service_running = service.running?
+      case options[:server]
+      when "start"
+        service.start unless service_running
+      when "stop"
+        service.stop if service_running
+      when "restart"
+        service.restart
+      else
+        raise "Invalid server action"
+      end
     end
 
     def self.parse(args)

--- a/spec/appliance_console/cli_spec.rb
+++ b/spec/appliance_console/cli_spec.rb
@@ -227,6 +227,38 @@ describe ApplianceConsole::Cli do
     end
   end
 
+  context "#set_server_state" do
+    let(:evm_service) { double("evmserved") }
+    before do
+      allow(LinuxAdmin::Service).to receive(:new).with("evmserverd").and_return(evm_service)
+    end
+
+    it "state is start" do
+      expect(evm_service).to receive(:running?).and_return(false)
+      expect(evm_service).to receive(:start)
+      subject.parse(%w(--server start)).run
+    end
+
+    it "state is stop" do
+      expect(evm_service).to receive(:running?).and_return(true)
+      expect(evm_service).to receive(:stop)
+      subject.parse(%w(--server stop)).run
+    end
+
+    it "state is restart" do
+      expect(evm_service).to receive(:running?).and_return(true)
+      expect(evm_service).to receive(:restart)
+      subject.parse(%w(--server restart)).run
+    end
+
+    it "state is wrong" do
+      expect(evm_service).to receive(:running?).and_return(true)
+      expect do
+        subject.parse(%w(--server aa)).run
+      end.to raise_error(/Invalid server action/)
+    end
+  end
+
   context "#config_tmp_disk" do
     it "configures disk" do
       expect(subject).to receive(:disk_from_string).with('x').and_return('/dev/x')


### PR DESCRIPTION
I added an option to start,stop or get status from evmserverd. 
issue https://github.com/ManageIQ/manageiq-gems-pending/issues/54
What do you think about?? 
I wanna have more options in CLI. Maybe can divide all operations in topics if we wanna start service or make FS or configure something, like server, database,...

   