### PR TITLE
Add AcquireTicket method to VMwareWebService

### DIFF
--- a/lib/gems/pending/VMwareWebService/MiqVimVm.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimVm.rb
@@ -1228,6 +1228,13 @@ class MiqVimVm
     (rv)
   end # def acquireMksTicket
 
+  def acquireTicket(ticketType)
+    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: calling acquireTicket" if $vim_log
+    rv = @invObj.acquireTicket(@vmMor, ticketType)
+    $vim_log.info "MiqVimVm(#{@invObj.server}, #{@invObj.username}).acquireTicket: returned from acquireTicket" if $vim_log
+    (rv)
+  end # def acquireTicket
+
   def datacenterName
     @cacheLock.synchronize(:SH) do
       @datacenterName = @invObj.vmDatacenterName(@vmMor) unless @datacenterName

--- a/lib/gems/pending/VMwareWebService/VimService.rb
+++ b/lib/gems/pending/VMwareWebService/VimService.rb
@@ -46,6 +46,16 @@ class VimService < Handsoap::Service
     (parse_response(response, 'AcquireMksTicketResponse')['returnval'])
   end
 
+  def acquireTicket(mor, ticketType)
+    response = invoke("n1:AcquireTicket") do |message|
+      message.add "n1:_this", mor do |i|
+        i.set_attr "type", mor.vimType
+      end
+      message.add "n1:ticketType", ticketType
+    end
+    (parse_response(response, 'AcquireTicketResponse')['returnval'])
+  end
+
   def addHost_Task(clustMor, spec, asConnected, resourcePool = nil, license = nil)
     response = invoke("n1:AddHost_Task") do |message|
       message.add "n1:_this", clustMor do |i|


### PR DESCRIPTION
The `VirtualMachine#AcquireTicket` method [0] was added in 4.1 and is required for using the newer `webmks` ticket type [1] (which was added in 6.0)

[0] https://www.vmware.com/support/developer/vc-sdk/visdk41pubs/ApiReference/vim.VirtualMachine.html#acquireTicket
[1] http://pubs.vmware.com/vsphere-60/index.jsp?topic=%2Fcom.vmware.wssdk.apiref.doc%2Fvim.VirtualMachine.TicketType.html

Blocks: https://github.com/ManageIQ/manageiq-providers-vmware/pull/9

https://github.com/ManageIQ/manageiq/issues/13798