### PR TITLE
Prevent Trollop from exiting the rspec process

### DIFF
--- a/spec/appliance_console/cli_spec.rb
+++ b/spec/appliance_console/cli_spec.rb
@@ -3,6 +3,18 @@ require "appliance_console/cli"
 describe ApplianceConsole::Cli do
   subject { described_class.new }
 
+  describe "#parse" do
+    it "fails if a region is not specified for a local database" do
+      expect { subject.parse(%w(--internal)) }.to raise_error(TrollopDieSpecError)
+    end
+  end
+
+  describe "#run" do
+    it "should educate if parameters are not passed" do
+      expect { subject.parse([]).run }.to raise_error(TrollopEducateSpecError)
+    end
+  end
+
   it "should set hostname if defined" do
     expect_any_instance_of(LinuxAdmin::Hosts).to receive(:hostname=).with('host1')
     expect_any_instance_of(LinuxAdmin::Hosts).to receive(:save).and_return(true)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,21 +19,9 @@ Dir.mkdir(RAILS_ROOT.join("log"))
 # in ./support/ and its subdirectories.
 Dir[File.expand_path(File.join(__dir__, 'support/**/*.rb'))].each { |f| require f }
 
-class TrollopEducateSpecError < StandardError; end
-class TrollopDieSpecError < StandardError; end
-
 RSpec.configure do |config|
   config.after(:each) do
     Module.clear_all_cache_with_timeout if Module.respond_to?(:clear_all_cache_with_timeout)
-  end
-
-  config.before(:each) do
-    err_string = <<-EOF.strip_heredoc
-      Don't allow methods that exit the calling process to be executed in specs.
-      If you were testing that we call Trollop.educate or Trollop.die, expect that a TrollopEducateSpecError or TrollopDieSpecError be raised instead
-    EOF
-    allow(Trollop).to receive(:educate).and_raise(TrollopEducateSpecError.new(err_string))
-    allow(Trollop).to receive(:die).and_raise(TrollopDieSpecError.new(err_string))
   end
 
   if ENV["CI"]

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,9 +19,21 @@ Dir.mkdir(RAILS_ROOT.join("log"))
 # in ./support/ and its subdirectories.
 Dir[File.expand_path(File.join(__dir__, 'support/**/*.rb'))].each { |f| require f }
 
+class TrollopEducateSpecError < StandardError; end
+class TrollopDieSpecError < StandardError; end
+
 RSpec.configure do |config|
   config.after(:each) do
     Module.clear_all_cache_with_timeout if Module.respond_to?(:clear_all_cache_with_timeout)
+  end
+
+  config.before(:each) do
+    err_string = <<-EOF.strip_heredoc
+      Don't allow methods that exit the calling process to be executed in specs.
+      If you were testing that we call Trollop.educate or Trollop.die, expect that a TrollopEducateSpecError or TrollopDieSpecError be raised instead
+    EOF
+    allow(Trollop).to receive(:educate).and_raise(TrollopEducateSpecError.new(err_string))
+    allow(Trollop).to receive(:die).and_raise(TrollopDieSpecError.new(err_string))
   end
 
   if ENV["CI"]

--- a/spec/support/trollop.rb
+++ b/spec/support/trollop.rb
@@ -1,0 +1,13 @@
+class TrollopEducateSpecError < StandardError; end
+class TrollopDieSpecError < StandardError; end
+
+RSpec.configure do |config|
+  config.before(:each) do
+    err_string = <<-EOF.strip_heredoc
+      Don't allow methods that exit the calling process to be executed in specs.
+      If you were testing that we call Trollop.educate or Trollop.die, expect that a TrollopEducateSpecError or TrollopDieSpecError be raised instead
+    EOF
+    allow(Trollop).to receive(:educate).and_raise(TrollopEducateSpecError.new(err_string))
+    allow(Trollop).to receive(:die).and_raise(TrollopDieSpecError.new(err_string))
+  end
+end


### PR DESCRIPTION
`Trollop.die` and `Trollop.educate` exit the calling process with a 0 exit status.

This is undesirable as it will cause the spec suite to go green without having run all the specs. In addition, the writer of a spec that would cause the process to exit likely did not want that behavior and would expect the spec to fail.

This change achieves that behavior by stubbing the calls to `Trollop.die` and `Trollop.educate` to raise errors.

Now we can also test that these methods are called by expecting that these particular error classes are raised.