### PR TITLE
Require active_support and trollop in spec/support/trollop.rb

### DIFF
--- a/spec/support/trollop.rb
+++ b/spec/support/trollop.rb
@@ -1,3 +1,6 @@
+require 'active_support/core_ext/string/strip'
+require 'trollop'
+
 class TrollopEducateSpecError < StandardError; end
 class TrollopDieSpecError < StandardError; end
 


### PR DESCRIPTION
This prevents us from failing when `strip_heredoc` and trollop have not been previously required in a spec file.

This was happening when running individual specs such as `bundle exec rspec spec/util/postgres_admin_spec.rb`

Issue was introduced in https://github.com/ManageIQ/manageiq-gems-pending/pull/62

/cc @lfu 