### PR TITLE
Look for productized translation files under productization directory of the application

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -27,8 +27,11 @@ include HighLine::SystemExtensions
 
 require 'i18n'
 locales_dir = ENV['CONTAINER'] ? "container" : "appliance"
-LOCALES = File.expand_path(File.join("appliance_console/locales", locales_dir, "*.yml"), __dir__)
-I18n.load_path = Dir[LOCALES].sort
+locales_paths = [
+  File.expand_path(File.join("appliance_console/locales", locales_dir, "*.yml"), __dir__),
+  File.expand_path(File.join("productization/appliance_console/locales", locales_dir, "*.yml"), RAILS_ROOT)
+]
+locales_paths.each { |p| I18n.load_path += Dir[p].sort }
 I18n.enforce_available_locales = true
 I18n.backend.load_translations
 

--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -35,6 +35,8 @@ locales_paths.each { |p| I18n.load_path += Dir[p].sort }
 I18n.enforce_available_locales = true
 I18n.backend.load_translations
 
+SCAP_RULES_DIR = File.expand_path("productization/appliance_console/config", RAILS_ROOT)
+
 $terminal.wrap_at = 80
 $terminal.page_at = 35
 
@@ -595,7 +597,7 @@ Static Network Configuration
 
       when I18n.t("advanced_settings.scap")
         say("#{selection}\n\n")
-        ApplianceConsole::Scap.new.lockdown
+        ApplianceConsole::Scap.new(SCAP_RULES_DIR).lockdown
         press_any_key
 
       when I18n.t("advanced_settings.summary")

--- a/lib/gems/pending/appliance_console/scap.rb
+++ b/lib/gems/pending/appliance_console/scap.rb
@@ -2,6 +2,10 @@ require 'linux_admin'
 
 module ApplianceConsole
   class Scap
+    def initialize(rules_dir)
+      @rules_dir = rules_dir
+    end
+
     def lockdown
       if packages_installed? && config_exists?
         say("Locking down the appliance for SCAP...")
@@ -20,7 +24,7 @@ module ApplianceConsole
     private
 
     def yaml_filename
-      File.expand_path("config/scap_rules.yml", __dir__)
+      File.expand_path("scap_rules.yml", @rules_dir)
     end
 
     def packages_installed?


### PR DESCRIPTION
Now that gems/pending is a real gem, the productized translation files are no longer existing in a path relative to the ruby script that loads it in the gem. The files will now created under the productization directory during the build. We need to load files from that location as well.

https://bugzilla.redhat.com/show_bug.cgi?id=1422433

/cc @carbonin 