### PR TITLE
Update `ovirt` gem to 0.15.0

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -51,7 +51,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-sftp",                "~>2.1.2"
   s.add_runtime_dependency "nokogiri",                "~>1.6.8"
   s.add_runtime_dependency "openscap",                "~>0.4.3"
-  s.add_runtime_dependency "ovirt",                   "~>0.14.0"
+  s.add_runtime_dependency "ovirt",                   "~>0.15.0"
   s.add_runtime_dependency "parallel",                "~>1.9" # For OvirtInventory
   s.add_runtime_dependency "pg",                      "~>0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~>0.1.0"


### PR DESCRIPTION
This new version of the gem is needed because it introduces support for
checking the TLS certificates of the server.