### PR TITLE
Extract Networking Configuration to a submenu

### DIFF
--- a/lib/gems/pending/appliance_console/locales/appliance/en.yml
+++ b/lib/gems/pending/appliance_console/locales/appliance/en.yml
@@ -4,10 +4,7 @@ en:
     name: ManageIQ
   advanced_settings:
     menu_order:
-    - dhcp
-    - static
-    - testnet
-    - hostname
+    - networking
     - timezone
     - datetime
     - dbrestore
@@ -25,10 +22,7 @@ en:
     - shutdown
     - summary
     - quit
-    dhcp: Set DHCP Network Configuration
-    static: Set Static Network Configuration
-    testnet: Test Network Configuration
-    hostname: Set Hostname
+    networking: Set-up Networking
     timezone: Set Timezone
     datetime: Set Date and Time
     dbrestore: Restore Database From Backup


### PR DESCRIPTION
There were already 4 options for network configuration. With IPv6 this will be extended further.

Logically these 4 options are tight together and they are unrelated from other options. Once the user is done with networking, he or she may not want to return back.

I have been thinking about this and I wanted to avoid this move for a while. Then, I have come to a conclusion that this should pay off in the long run. There is growing ammount of options in the
appliance_console and separation will make it easier for mammals to comprehend.

This is how it looks now

```
Advanced Setting

1) Set-up Networking
2) Set Timezone
3) Set Date and Time
4) Restore Database From Backup
5) Configure Database
6) Configure Database Replication
7) Configure Database Maintenance
8) Logfile Configuration
9) Configure Application Database Failover Monitor
10) Configure External Authentication (httpd)
11) Update External Authentication Options
12) Generate Custom Encryption Key
13) Stop EVM Server Processes
14) Start EVM Server Processes
15) Restart Appliance
16) Shut Down Appliance
17) Summary Information
18) Quit
```
and
```
Network Configuration

1) Set DHCP Network Configuration
2) Set Static Network Configuration
3) Test Network Configuration
4) Set Hostname

Choose the network configuration: 
```

