### PR TITLE
Allow users to input ipv6 where it makes sense

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -171,11 +171,11 @@ To modify the configuration, use a web browser to access the management page.
         say("Static Network Configuration\n\n")
         say("Enter the new static network configuration settings.\n\n")
 
-        new_ip   = ask_for_ip("IP Address", ip)
-        new_mask = ask_for_ip("Netmask", mask)
-        new_gw   = ask_for_ip("Gateway", gw)
-        new_dns1 = ask_for_ip("Primary DNS", dns1)
-        new_dns2 = ask_for_ip_or_none("Secondary DNS (Enter 'none' for no value)")
+        new_ip   = ask_for_ipv4("IP Address", ip)
+        new_mask = ask_for_ipv4("Netmask", mask)
+        new_gw   = ask_for_ipv4("Gateway", gw)
+        new_dns1 = ask_for_ipv4("Primary DNS", dns1)
+        new_dns2 = ask_for_ipv4_or_none("Secondary DNS (Enter 'none' for no value)")
 
         new_search_order = ask_for_many("domain", "Domain search order", order)
 

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -6,7 +6,7 @@ module ApplianceConsole
   module Prompts
     CLEAR_CODE    = `clear`
     IPV4_REGEXP   = Resolv::IPv4::Regex
-    IP_REGEXP     = Resolv::IPv4::Regex
+    IP_REGEXP     = Regexp.union(Resolv::IPv4::Regex, Resolv::IPv6::Regex).freeze
     DOMAIN_REGEXP = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*(\.[a-z]{2,13})?$/
     INT_REGEXP    = /^[0-9]+$/
     HOSTNAME_REGEXP = /^(([a-zA-Z]|[a-zA-Z][a-zA-Z0-9\-]*[a-zA-Z0-9])\.)*([A-Za-z]|[A-Za-z][A-Za-z0-9\-]*[A-Za-z0-9])$/

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -5,6 +5,7 @@ module ApplianceConsole
 
   module Prompts
     CLEAR_CODE    = `clear`
+    IPV4_REGEXP   = Resolv::IPv4::Regex
     IP_REGEXP     = Resolv::IPv4::Regex
     DOMAIN_REGEXP = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*(\.[a-z]{2,13})?$/
     INT_REGEXP    = /^[0-9]+$/
@@ -68,8 +69,12 @@ module ApplianceConsole
       just_ask(prompt, default, validate, error_text, &block)
     end
 
-    def ask_for_ip_or_none(prompt, default = nil)
-      validation = ->(p) { p.empty? || p =~ /^'?NONE'?$/i || p =~ IP_REGEXP }
+    def ask_for_ipv4(prompt, default)
+      ask_for_ip(prompt, default, IPV4_REGEXP)
+    end
+
+    def ask_for_ipv4_or_none(prompt, default = nil)
+      validation = ->(p) { p.empty? || p =~ /^'?NONE'?$/i || p =~ IPV4_REGEXP }
       ask_for_ip(prompt, default, validation).gsub(/^'?NONE'?$/i, "")
     end
 

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -135,6 +135,11 @@ describe ApplianceConsole::Prompts do
       expect_heard "Enter the prompt: |1.1.1.1| "
     end
 
+    it 'supports ipv6' do
+      say '::1'
+      expect(subject.ask_for_ip('prompt', '1.1.1.1')).to eq('::1')
+    end
+
     context "#or_none" do
       it "should handle default" do
         say ""
@@ -166,6 +171,11 @@ describe ApplianceConsole::Prompts do
         say "2.2.2.2"
         expect(subject.ask_for_ip_or_hostname("prompt", "1.1.1.1")).to eq("2.2.2.2")
         expect_heard("Enter the prompt: |1.1.1.1| ")
+      end
+
+      it 'supports ipv6' do
+        say 'dead:beef::1'
+        expect(subject.ask_for_ip('prompt', '1.1.1.1')).to eq('dead:beef::1')
       end
 
       it "should handle hostname" do

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -138,19 +138,19 @@ describe ApplianceConsole::Prompts do
     context "#or_none" do
       it "should handle default" do
         say ""
-        expect(subject.ask_for_ip_or_none("prompt", "1.1.1.1")).to eq("1.1.1.1")
+        expect(subject.ask_for_ipv4_or_none("prompt", "1.1.1.1")).to eq("1.1.1.1")
         expect_heard("Enter the prompt: |1.1.1.1| ")
       end
 
       it "should handle blank" do
         say ""
-        expect(subject.ask_for_ip_or_none("prompt")).to eq("")
+        expect(subject.ask_for_ipv4_or_none("prompt")).to eq("")
         expect_heard("Enter the prompt: ")
       end
 
       it "should handle none" do
         say "none"
-        expect(subject.ask_for_ip_or_none("prompt", "1.1.1.1")).to eq("")
+        expect(subject.ask_for_ipv4_or_none("prompt", "1.1.1.1")).to eq("")
         expect_heard("Enter the prompt: |1.1.1.1| ")
       end
     end


### PR DESCRIPTION
## What
In many prompts we allow users to put IP address. In some prompts it makes sense to only accept IPv4 addresses (when setting up static IPv4). In other cases it makes sense to accept IPv4 or IPv6.

This PR makes `Test Network Configuration` to magically work with IPv6.

I'll continue to work with other dialogs to make sure, we are able to process IPv6. However, we can allow IPv6 inputs to be valid now.