### PR TITLE
Extends standby database gem to use an external disk if available.

### DIFF
--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -78,14 +78,14 @@ module ApplianceConsole
       data_dir_empty? &&
         initialize_postgresql_disk if disk
         PostgresAdmin.prep_data_directory &&
-        relabel_postgresql_dir &&
-        generate_cluster_name &&
-        create_config_file(standby_host) &&
-        clone_standby_server &&
-        start_postgres &&
-        register_standby_server &&
-        write_pgpass_file &&
-        (run_repmgrd_configuration ? start_repmgrd : true)
+          relabel_postgresql_dir &&
+          generate_cluster_name &&
+          create_config_file(standby_host) &&
+          clone_standby_server &&
+          start_postgres &&
+          register_standby_server &&
+          write_pgpass_file &&
+          (run_repmgrd_configuration ? start_repmgrd : true)
     end
 
     def data_dir_empty?

--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -93,10 +93,6 @@ module ApplianceConsole
       false
     end
 
-    def relabel_postgresql_dir
-      AwesomeSpawn.run!("/sbin/restorecon -R -v #{mount_point}")
-    end
-
     def clone_standby_server
       params = { :h  => primary_host,
                  :U  => database_user,

--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -38,7 +38,7 @@ module ApplianceConsole
     end
 
     def choose_disk
-       @disk = ask_for_disk("database disk")
+      @disk = ask_for_disk("database disk")
     end
 
     def initialize_postgresql_disk

--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -71,15 +71,15 @@ module ApplianceConsole
     def activate
       say("Configuring Replication Standby Server...")
       initialize_postgresql_disk if disk
-      PostgresAdmin.prep_data_directory &&
-        data_dir_empty?
+      PostgresAdmin.prep_data_directory
+      data_dir_empty? &&
         generate_cluster_name &&
-          create_config_file(standby_host) &&
-          clone_standby_server &&
-          start_postgres &&
-          register_standby_server &&
-          write_pgpass_file &&
-          (run_repmgrd_configuration ? start_repmgrd : true)
+        create_config_file(standby_host) &&
+        clone_standby_server &&
+        start_postgres &&
+        register_standby_server &&
+        write_pgpass_file &&
+        (run_repmgrd_configuration ? start_repmgrd : true)
     end
 
     def data_dir_empty?

--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -72,14 +72,14 @@ module ApplianceConsole
       say("Configuring Replication Standby Server...")
       initialize_postgresql_disk if disk
       PostgresAdmin.prep_data_directory &&
-        data_dir_empty? &&
+        data_dir_empty?
         generate_cluster_name &&
-        create_config_file(standby_host) &&
-        clone_standby_server &&
-        start_postgres &&
-        register_standby_server &&
-        write_pgpass_file &&
-        (run_repmgrd_configuration ? start_repmgrd : true)
+          create_config_file(standby_host) &&
+          clone_standby_server &&
+          start_postgres &&
+          register_standby_server &&
+          write_pgpass_file &&
+          (run_repmgrd_configuration ? start_repmgrd : true)
     end
 
     def data_dir_empty?

--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -50,8 +50,10 @@ module ApplianceConsole
 
     def confirm
       super
-      say(<<-EOS)
+      say(<<-EOS) if disk
         Database Disk:              #{disk}
+      EOS
+      say(<<-EOS)
         Standby Host:               #{standby_host}
         Automatic Failover:         #{run_repmgrd_configuration ? "enabled" : "disabled"}
       EOS

--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -78,14 +78,14 @@ module ApplianceConsole
       data_dir_empty? &&
         initialize_postgresql_disk if disk
         PostgresAdmin.prep_data_directory &&
-          relabel_postgresql_dir &&
-          generate_cluster_name &&
-          create_config_file(standby_host) &&
-          clone_standby_server &&
-          start_postgres &&
-          register_standby_server &&
-          write_pgpass_file &&
-          (run_repmgrd_configuration ? start_repmgrd : true)
+        relabel_postgresql_dir &&
+        generate_cluster_name &&
+        create_config_file(standby_host) &&
+        clone_standby_server &&
+        start_postgres &&
+        register_standby_server &&
+        write_pgpass_file &&
+        (run_repmgrd_configuration ? start_repmgrd : true)
     end
 
     def data_dir_empty?

--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -13,6 +13,10 @@ class PostgresAdmin
     Pathname.new(ENV.fetch("APPLIANCE_PG_DATA"))
   end
 
+  def self.mount_point
+    Pathname.new(ENV.fetch("APPLIANCE_PG_MOUNT_POINT"))
+  end
+
   def self.template_directory
     Pathname.new(ENV.fetch("APPLIANCE_TEMPLATE_DIRECTORY"))
   end

--- a/spec/appliance_console/database_replication_standby_spec.rb
+++ b/spec/appliance_console/database_replication_standby_spec.rb
@@ -20,11 +20,6 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     allow(subject).to receive(:ask_for_password_or_none)
   end
 
-  it "#choose_disk" do
-    expect(@config).to receive(:ask_for_disk)
-    @config.choose_disk
-  end
-
   context "#ask_questions" do
     before do
       expect(subject).to receive(:ask_for_unique_cluster_node_number)

--- a/spec/appliance_console/database_replication_standby_spec.rb
+++ b/spec/appliance_console/database_replication_standby_spec.rb
@@ -20,6 +20,11 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     allow(subject).to receive(:ask_for_password_or_none)
   end
 
+  it "#choose_disk" do
+    expect(@config).to receive(:ask_for_disk)
+    @config.choose_disk
+  end
+
   context "#ask_questions" do
     before do
       expect(subject).to receive(:ask_for_unique_cluster_node_number)


### PR DESCRIPTION
Resolves https://github.com/ManageIQ/manageiq-gems-pending/issues/33

The nightly manageiq build isn't exactly cooperating when trying to set up a DB replica, so there might be issues as I wasn't able to test properly.

I have attached a similar patch but for 5.7.0.17 (where database_replication_standby.rb is quite different from upstream) to https://bugzilla.redhat.com/show_bug.cgi?id=1425327 .

Cheers
Luca