### PR TITLE
Validate nfs and smb endpoints over ipv6

### DIFF
--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -30,7 +30,7 @@ module ApplianceConsole
           u = URI(a)
           # validate it has a hostname/ip and a share
           u.scheme == expected_scheme &&
-            (u.host =~ HOSTNAME_REGEXP || u.host =~ IP_REGEXP) &&
+            (u.host =~ HOSTNAME_REGEXP || u.hostname =~ IP_REGEXP) &&
             !u.path.empty?
         end
       end

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -27,9 +27,11 @@ module ApplianceConsole
           # Convert all backslashes in the URI to forward slashes and strip whitespace
           a.tr!('\\', '/')
           a.strip!
-          scheme, _, host, _, _, path, = URI.split(URI.encode(a))
+          u = URI(a)
           # validate it has a hostname/ip and a share
-          scheme == expected_scheme && (host.to_s =~ HOSTNAME_REGEXP || host.to_s =~ IP_REGEXP) && path.to_s.length > 0
+          u.scheme == expected_scheme &&
+            (u.host =~ HOSTNAME_REGEXP || u.host =~ IP_REGEXP) &&
+            !u.path.empty?
         end
       end
     end

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -58,6 +58,13 @@ describe ApplianceConsole::Prompts do
       expect(subject.ask_for_uri("prompt", "nfs")).to eq(response)
       expect_heard ["Enter the prompt: ", "Please provide a valid URI", prompt]
     end
+
+    it 'supports IPv6' do
+      response = 'nfs://[d:e:a:d:b:e:e:f]/path/file.txt'
+      say response
+      expect(subject.ask_for_uri('prompt', 'nfs')).to eq(response)
+      expect_heard('Enter the prompt: ')
+    end
   end
 
   context "#ask_for_many" do


### PR DESCRIPTION
## What
The validation of URI needs a smallish amend to allow for uri like:
```
nfs://[2620:52:0:2804:3fec:900f:ca31:a115]/export/db.backup
```

@miq-bot add_label appliance/console