### PR TITLE
Use localhost shortcut in dialogs to configure internal db

### DIFF
--- a/lib/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/internal_database_configuration.rb
@@ -24,7 +24,7 @@ module ApplianceConsole
     end
 
     def set_defaults
-      self.host              = "127.0.0.1"
+      self.host              = 'localhost'
       self.username          = "root"
       self.database          = "vmdb_production"
       self.run_as_evm_server = true

--- a/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/spec/appliance_console/internal_database_configuration_spec.rb
@@ -13,7 +13,7 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
 
   context ".new" do
     it "set defaults automatically" do
-      expect(@config.host).to eq("127.0.0.1")
+      expect(@config.host).to eq('localhost')
       expect(@config.username).to eq("root")
       expect(@config.database).to eq("vmdb_production")
       expect(@config.run_as_evm_server).to be true


### PR DESCRIPTION
s/127.0.0.1/localhost/ for internal db config.

Let's not bother ipv6 only admins with archaic quaternion.

## Previously:
```
Each database region number must be unique.
Enter the database region number: 1
Enter the database password on 127.0.0.1: *******
```

## Now
```
Each database region number must be unique.
Enter the database region number: 1
Enter the database password on localhost: *******
```