### PR TITLE
appliance_console: dialog for static ipv6 settings

### DIFF
--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -6,6 +6,7 @@ module ApplianceConsole
   module Prompts
     CLEAR_CODE    = `clear`
     IPV4_REGEXP   = Resolv::IPv4::Regex
+    IPV6_REGEXP   = Resolv::IPv6::Regex
     IP_REGEXP     = Regexp.union(Resolv::IPv4::Regex, Resolv::IPv6::Regex).freeze
     DOMAIN_REGEXP = /^[a-z0-9]+([\-\.]{1}[a-z0-9]+)*(\.[a-z]{2,13})?$/
     INT_REGEXP    = /^[0-9]+$/
@@ -78,6 +79,14 @@ module ApplianceConsole
 
     def ask_for_ipv4_or_none(prompt, default = nil)
       ask_for_ip(prompt, default, Regexp.union(NONE_REGEXP, IPV4_REGEXP)).gsub(NONE_REGEXP, "")
+    end
+
+    def ask_for_ipv6(prompt, default)
+      ask_for_ip(prompt, default, IPV6_REGEXP)
+    end
+
+    def ask_for_ipv6_or_none(prompt, default = nil)
+      ask_for_ip(prompt, default, Regexp.union(IPV6_REGEXP, NONE_REGEXP)).gsub(NONE_REGEXP, '')
     end
 
     def ask_for_hostname(prompt, default = nil, validate = HOSTNAME_REGEXP, error_text = "a valid Hostname.", &block)

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"
   s.add_runtime_dependency "iniparse"
   s.add_runtime_dependency "kubeclient",              "=2.3.0"
-  s.add_runtime_dependency "linux_admin",             "~>0.19.0"
+  s.add_runtime_dependency "linux_admin",             "~>0.20.0"
   s.add_runtime_dependency "linux_block_device",      "~>0.2.1"
   s.add_runtime_dependency "log4r",                   "=1.1.8"
   s.add_runtime_dependency "memoist",                 "~>0.14.0"


### PR DESCRIPTION
## Dependencies
- [x] depends on ~~https://github.com/ManageIQ/linux_admin/pull/176~~ or https://github.com/ManageIQ/linux_admin/pull/181
- [x] depends on https://github.com/ManageIQ/linux_admin/pull/177
- [x] depends on https://github.com/ManageIQ/linux_admin/pull/178

## This is how it looks:
```
IPv6: Static Network Configuration

Enter the new static network configuration settings.

Enter the IP Address: |2620:52:0:2804:3fec:900f:ca31:a115| 
Enter the IPv6 prefix length: |64| 
Enter the Default gateway: |fe80:52:0:2804::1fc| 
Enter the Primary DNS: |10.38.5.26| fe80:52:0:2804::1fd
Enter the Secondary DNS (Enter 'none' for no value): none
Enter the Domain search order: |brq.redhat.com redhat.com|
```
and then
```
Static Network Configuration

        IP Address:      2620:52:0:2804:3fec:900f:ca31:a115/64
        Gateway:         fe80:52:0:2804::1fc
        Primary DNS:     fe80:52:0:2804::1fd
        Secondary DNS:   
        Search Order:    brq.redhat.com redhat.com

Apply static network configuration? (Y/N)
```
