### PR TITLE
Fixed dynamic 'require ...' in ScanProfileBase

### DIFF
--- a/lib/gems/pending/metadata/ScanProfile/ScanProfilesBase.rb
+++ b/lib/gems/pending/metadata/ScanProfile/ScanProfilesBase.rb
@@ -7,7 +7,7 @@ class ScanProfilesBase
     return k unless k.nil?
 
     k = "#{from.name.underscore.split('_')[0..-2].join('_').camelize}#{type.camelize}"
-    require k
+    require "metadata/ScanProfile/#{k}"
     from.instance_variable_set("@scan_#{type}_class", Object.const_get(k))
   end
 

--- a/spec/metadata/ScanProfile/ScanProfileBase_spec.rb
+++ b/spec/metadata/ScanProfile/ScanProfileBase_spec.rb
@@ -1,0 +1,30 @@
+require 'metadata/ScanProfile/HostScanProfiles'
+require 'metadata/ScanProfile/VmScanProfiles'
+
+describe ScanProfilesBase do
+  describe ".get_class" do
+    context "HostScan" do
+      it "returns HostScanProfile.class with 'profile' parameter" do
+        klass = described_class.get_class('profile', HostScanProfiles.scan_profiles_class)
+        expect(klass).to be_a(HostScanProfile.class) 
+      end
+
+      it "returns HostScanItem.class with 'item' parameter" do
+        klass = described_class.get_class('item', HostScanProfiles.scan_profiles_class)
+        expect(klass).to be_a(HostScanItem.class)
+      end
+    end
+
+    context "VmScan" do
+      it "returns VmScanProfile.class  with 'profile' parameter" do
+        klass = described_class.get_class('profile', VmScanProfiles.scan_profiles_class)
+        expect(klass).to be_a(VmScanProfile.class)
+      end
+
+      it "returns VmScanProfile.class with 'item' parameter" do
+        klass = described_class.get_class('item', VmScanProfiles.scan_profiles_class)
+        expect(klass).to be_a(VmScanItem.class)
+      end
+    end
+  end
+end


### PR DESCRIPTION
There was error: " `require': cannot load such file -- HostScanProfile (LoadError) "  when starting SmartState Analysis on host

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1430770

\cc @jerryk55 @roliveri @Fryguy