### PR TITLE
Favor Apache over Rails to display HTTP error documents

### DIFF
--- a/lib/gems/pending/util/miq_apache/miq_apache.rb
+++ b/lib/gems/pending/util/miq_apache/miq_apache.rb
@@ -215,6 +215,10 @@ module MiqApache
           content << "RewriteCond \%{REQUEST_URI} !^/ansibleapi\n"
           content << "RewriteCond \%{DOCUMENT_ROOT}/\%{REQUEST_FILENAME} !-f\n"
           content << "RewriteRule ^#{redirect} balancer://#{opts[:cluster]}\%{REQUEST_URI} [P,QSA,L]\n"
+          content << "ErrorDocument 404 /404.html\n"
+          content << "ErrorDocument 422 /422.html\n"
+          content << "ErrorDocument 500 /500.html\n"
+          content << "ProxyErrorOverride On\n"
         else
           content << "ProxyPass #{redirect} balancer://#{opts[:cluster]}#{redirect}\n"
         end


### PR DESCRIPTION
This bring us closer to unified error pages in both UIs https://github.com/ManageIQ/manageiq/issues/14244