### PR TITLE
Log any exceptions when trying to validate apache configurations

### DIFF
--- a/lib/gems/pending/util/miq_apache/miq_apache.rb
+++ b/lib/gems/pending/util/miq_apache/miq_apache.rb
@@ -128,8 +128,8 @@ module MiqApache
       ###################################################################
       begin
         res = MiqUtil.runcmd('apachectl configtest')
-      rescue
-        $log.warn("MIQ(MiqApache::Control.config_ok?) Configuration syntax failed with error: #{res}") if $log
+      rescue => err
+        $log.warn("MIQ(MiqApache::Control.config_ok?) Configuration syntax failed with error: #{err} for result: #{res}") if $log
         return false
       end
       return true if res =~ /Syntax OK/


### PR DESCRIPTION
Related to https://github.com/ManageIQ/manageiq/pull/14311

Previously, we quietly logged no result and lost the details of the
exception.  Now, we log the exception and any result if any...

Before:
```
[----] W, [2017-03-13T17:45:37.678276 #2555:b6b14c]  WARN -- : MIQ(MiqApache::Control.config_ok?) Configuration syntax failed with error:
[----] W, [2017-03-13T17:45:37.678401 #2555:b6b14c]  WARN -- : MIQ(MiqApache::Conf.save) Restoring old configuration due to bad configuration!
```

After:

```
[----] W, [2017-03-13T17:45:37.678276 #2555:b6b14c]  WARN -- : MIQ(MiqApache::Control.config_ok?) Configuration syntax failed with error: httpd: Syntax error on line 353 of /etc/httpd/conf/httpd.conf: Syntax error on line 12 of /etc/httpd/conf.d/manageiq-https-application.conf: Could not open configuration file /etc/httpd/conf.d/manageiq-redirects-websocket: No such file or directory
 for result:
[----] W, [2017-03-13T17:45:37.678401 #2555:b6b14c]  WARN -- : MIQ(MiqApache::Conf.save) Restoring old configuration due to bad configuration!
```