### PR TITLE
Don't analyze files we don't care to improve their quality.

### DIFF
--- a/.codeclimate.yml
+++ b/.codeclimate.yml
@@ -10,6 +10,11 @@ exclude_paths:
 - "spec/"
 - "test/"
 - "tmp/"
+- "lib/gems/pending/*/test/"
+- "lib/gems/pending/metadata/linux/test/Packages"
+- "lib/gems/pending/metadata/linux/test/tc_LinuxUtils.rb"
+- "lib/gems/pending/VcoWebService/vmwo.wsdl"
+- "lib/gems/pending/VMwareWebService/wsdl41/"
 engines:
   brakeman:
     # very slow :sad_panda:


### PR DESCRIPTION
These files were not being analyzed before, we shouldn't do them now.
They were either generated or something we don't really care to improve
right now.

We removed them here:
https://github.com/ManageIQ/manageiq/commit/afebc779a8c5e6c3863419a81709eecd952c902f

but, didn't exclude them in the extracted repo.

[skip ci]