### PR TITLE
Use apachectl configtest exit code to test syntax.

### DIFF
--- a/lib/gems/pending/util/miq_apache/miq_apache.rb
+++ b/lib/gems/pending/util/miq_apache/miq_apache.rb
@@ -130,12 +130,10 @@ module MiqApache
         res = MiqUtil.runcmd('apachectl configtest')
       rescue => err
         $log.warn("MIQ(MiqApache::Control.config_ok?) Configuration syntax failed with error: #{err} for result: #{res}") if $log
-        return false
+        false
+      else
+        true
       end
-      return true if res =~ /Syntax OK/
-      $log.warn("MIQ(MiqApache::Control.config_ok?) Configuration syntax failed with error: #{res}") if $log
-
-      false
     end
 
     private

--- a/spec/util/miq_apache/control_spec.rb
+++ b/spec/util/miq_apache/control_spec.rb
@@ -84,21 +84,14 @@ describe MiqApache::Control do
     expect(MiqApache::Control.status(false)).to be_nil
   end
 
-  it "should return true with when calling config_ok? and result was 'Syntax OK'" do
-    result = "Syntax OK"
-    allow(MiqUtil).to receive(:runcmd).and_return(result)
-    expect(MiqApache::Control).to be_config_ok
+  it "config_ok? is true if nothing raised" do
+    allow(MiqUtil).to receive(:runcmd)
+    expect(described_class.config_ok?).to be_truthy
   end
 
-  it "should return false with when calling config_ok? and an error was raised" do
-    allow(MiqUtil).to receive(:runcmd).and_raise("some error message")
-    expect(MiqApache::Control).not_to be_config_ok
-  end
-
-  it "should return false with when calling config_ok? and result was NOT 'Syntax OK'" do
-    result = "Blah!"
-    allow(MiqUtil).to receive(:runcmd).and_return(result)
-    expect(MiqApache::Control).not_to be_config_ok
+  it "config_ok? is false when error was raised" do
+    allow(MiqUtil).to receive(:runcmd).and_raise(StandardError)
+    expect(described_class.config_ok?).to be_falsey
   end
 
   it "should runcmd with rpm -qa... when calling version" do


### PR DESCRIPTION
It's brittle to check the standard output/error for "Syntax Ok".

The exit code should be non-zero when there's a problem:

With invalid syntax:
```
[root@localhost ~]# apachectl configtest
httpd: Syntax error on line 353 of /etc/httpd/conf/httpd.conf: Syntax
error on line 2 of /etc/httpd/conf.d/manageiq-balancer-ui.conf: Expected
</Proxy2> but saw </Proxy>
[root@localhost ~]# echo $?
1
```

With valid syntax:
```
[root@localhost ~]# apachectl configtest
[Tue Mar 14 11:39:56.933429 2017] [so:warn] [pid 16656] AH01574: module
ssl_module is already loaded, skipping
AH00558: httpd: Could not reliably determine the server's fully
qualified domain name, using localhost.localdomain. Set the 'ServerName'
directive globally to suppress this message
Syntax OK
[root@localhost ~]# echo $?
0
```