### PR TITLE
Bump nokogiri version

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "more_core_extensions",    "~>3.2"
   s.add_runtime_dependency "net-scp",                 "~>1.2.1"
   s.add_runtime_dependency "net-sftp",                "~>2.1.2"
-  s.add_runtime_dependency "nokogiri",                "~>1.6.8"
+  s.add_runtime_dependency "nokogiri",                ">=1.7"
   s.add_runtime_dependency "openscap",                "~>0.4.3"
   s.add_runtime_dependency "ovirt",                   "~>0.15.1"
   s.add_runtime_dependency "parallel",                "~>1.9" # For OvirtInventory


### PR DESCRIPTION
In linux_admin gem, there is CI job with name that rhymes with harakiri. That job started to fail on nokogiri and required linux_admin maintainers to bump the requirement to

    nokogiri => 1.7

that caused failures on developer set-ups as follows

    Bundler could not find compatible versions for gem "nokogiri":
    In Gemfile:
      linux_admin was resolved to 0.19.0, which depends on
        nokogiri (>= 1.7)

      manageiq-gems-pending was resolved to 0.1.0, which depends on
        nokogiri (~> 1.6.8)

The last time we bumped this was d832b550fe5d03f4cdc2fadf9c760545fb2aa6d8

For more info see https://github.com/ManageIQ/linux_admin/pull/180#issuecomment-288069020