### PR TITLE
Allow users to enable DHCPv6

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -165,7 +165,11 @@ To modify the configuration, use a web browser to access the management page.
         case ask_with_menu('Network Configuration', options)
         when 'dhcp'
           say("DHCP Network Configuration\n\n")
-          if agree("Apply DHCP network configuration? (Y/N): ")
+
+          ipv4 = agree('Enable DHCP for IPv4 network configuration? (Y/N): ')
+          ipv6 = agree('Enable DHCP for IPv6 network configuration? (Y/N): ')
+
+          if ipv4 || ipv6
             say("\nApplying DHCP network configuration...")
 
             resolv = LinuxAdmin::Dns.new
@@ -173,7 +177,8 @@ To modify the configuration, use a web browser to access the management page.
             resolv.nameservers = []
             resolv.save
 
-            eth0.enable_dhcp
+            eth0.enable_dhcp if ipv4
+            eth0.enable_dhcp6 if ipv6
             eth0.save
 
             say("\nAfter completing the appliance configuration, please restart #{I18n.t("product.name")} server processes.")


### PR DESCRIPTION
Most often users will want to just enable dhcp for both (ipv4, ipv6), so I bundle them together into a single dialog.

 - [x] depends on https://github.com/ManageIQ/linux_admin/pull/185

@miq-bot add_label enhancement