### PR TITLE
Update the armrest version to 0.7.0.

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",           ">= 5.0", "< 5.1"
   s.add_runtime_dependency "addressable",             "~> 2.4"
   s.add_runtime_dependency "awesome_spawn",           "~> 1.4"
-  s.add_runtime_dependency "azure-armrest",           "~> 0.5.2"
+  s.add_runtime_dependency "azure-armrest",           "~> 0.7.0"
   s.add_runtime_dependency "bcrypt",                  "~> 3.1.10"
   s.add_runtime_dependency "binary_struct",           "~> 2.1"
   s.add_runtime_dependency "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
@@ -43,7 +43,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "linux_admin",             "~>0.19.0"
   s.add_runtime_dependency "linux_block_device",      "~>0.2.1"
   s.add_runtime_dependency "log4r",                   "=1.1.8"
-  s.add_runtime_dependency "memoist",                 "~>0.14.0"
+  s.add_runtime_dependency "memoist",                 "~>0.15.0"
   s.add_runtime_dependency "memory_buffer",           ">=0.1.0"
   s.add_runtime_dependency "more_core_extensions",    "~>3.2"
   s.add_runtime_dependency "net-scp",                 "~>1.2.1"


### PR DESCRIPTION
This PR is to keep things in sync with the Azure provider repo.

https://github.com/ManageIQ/manageiq-providers-azure/pull/42

As with that PR, the major version changes shouldn't be scary. The change from 0.5.x to 0.6.x was caused by an incompatible change to Role classes that we don't use internally. The change from 0.6.x to 0.7.x is the backwards incompatible, but necessary, change for getting templates.

Update: I had to update the memoist dependency in order to avoid a conflict.