### PR TITLE
Add ruby 2.4 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ language: ruby
 rvm:
   - 2.2.6
   - 2.3.3
+  - 2.4.1
 before_install: gem install bundler -v 1.12.5
 after_script: bundle exec codeclimate-test-reporter


### PR DESCRIPTION

~~* Copied the webmock patch from https://github.com/ManageIQ/manageiq/pull/13104~~

~~* [This code is looking for Bignum and fails on ruby 2.4](https://github.com/ManageIQ/manageiq-gems-pending/blob/8dacc4146c526493bc8f83f661bcf84dbc2220ac/lib/gems/pending/fs/ntfs/directory_index_node.rb#L55).  Bignum and Fixnum were merged to Integer in ruby 2.4.  It doesn't look like can just replace Bignum with Integer.  I tried.~~

EDIT: see https://github.com/ManageIQ/manageiq-smartstate/pull/10