### PR TITLE
Bump hawkular-client gem version to 2.9.0

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "ffi",                     "~>1.9.3"
   s.add_runtime_dependency "ffi-vix_disk_lib",        "~>1.0.2"  # used by lib/VixDiskLib
   s.add_runtime_dependency "fog-openstack",           "=0.1.20"
-  s.add_runtime_dependency "hawkular-client",         "=2.8.0"
+  s.add_runtime_dependency "hawkular-client",         "=2.9.0"
   s.add_runtime_dependency "highline",                "~> 1.6.21" # Needed for the appliance_console
   s.add_runtime_dependency "httpclient",              "~>2.7.1"
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"


### PR DESCRIPTION
Version 2.9.0 of hawkular-client gem was released on March 13th. Some
deprecations were made. Bumping version to be able to stop using the
deprecated names in ManageIQ code.