### PR TITLE
Add LogDumpObject.

### DIFF
--- a/lib/gems/pending/util/log_dump_object.rb
+++ b/lib/gems/pending/util/log_dump_object.rb
@@ -1,0 +1,35 @@
+require 'active_support/concern'
+
+module LogDumpObject
+  extend ActiveSupport::Concern
+
+  module ClassMethods
+    def dump_obj(obj, prefix = nil, &block)
+      meth = "dump_#{obj.class.name.underscore}".to_sym
+
+      if self.respond_to?(meth)
+        return send(meth, obj, prefix, &block)
+      end
+
+      yield obj, prefix
+    end
+
+    def dump_hash(hd, prefix, &block)
+      hd.each { |k, v| dump_obj(v, "#{prefix}[#{k.inspect}]", &block) }
+    end
+
+    def dump_array(ad, prefix, &block)
+      ad.each_with_index { |d, i| dump_obj(d, "#{prefix}[#{i}]", &block) }
+    end
+  end
+
+  def dump_obj(obj, prefix = nil, options = {})
+    self.class.dump_obj(obj, prefix) do |val, prefix|
+      value = val
+      if options.try(:protected).try(:path).to_miq_a.any? { |filter| prefix =~ filter }
+        value = "<PROTECTED>"
+      end
+      $log.info("#{prefix}(#{val.class}) = #{value.inspect}")
+    end
+  end
+end

--- a/spec/util/log_dump_object_spec.rb
+++ b/spec/util/log_dump_object_spec.rb
@@ -1,0 +1,41 @@
+require 'util/log_dump_object'
+require 'util/extensions/miq-array'
+
+describe LogDumpObject do
+  before do
+    @test_object = Class.new do
+      include LogDumpObject
+    end.new
+  end
+
+  describe '#dump_obj' do
+    it "calls .dump_obj" do
+      expect(@test_object.class).to receive(:dump_obj)
+      @test_object.dump_obj({:param_1 => 1})
+    end
+
+    it 'hides passwords' do
+      @test_object.dump_obj(
+        {:my_password => "secret"},
+        "my choices: ",
+        :protected => {:path => /[Pp]assword/}
+      ) do |obj, prefix|
+        expect(obj).to eq("secret")
+        expect(prefix).to eq("my choices: [:my_password]")
+        expect($log).to receive(:info).with(/ = <PROTECTED>/)
+      end
+    end
+  end
+
+  describe '.dump_obj' do
+    it 'accepts a hash' do
+      expect(@test_object.class).to receive(:dump_hash)
+      @test_object.class.dump_obj({:param_1 => 1}) {}
+    end
+
+    it 'accepts an array' do
+      expect(@test_object.class).to receive(:dump_array)
+      @test_object.class.dump_obj(%w(1 2 3)) {}
+    end
+  end
+end


### PR DESCRIPTION
Move the common code out of MiqRequestTask::Dumping.
Part of [Refactor MiqRequestTask::Dumping. #14547](https://github.com/ManageIQ/manageiq/pull/14547).

@miq-bot assign @gmcculloug 
@miq-bot add_label fine/yes, euwe/no
cc @bzwei 