### PR TITLE
Fix Openstack Services SSA Host parsing

### DIFF
--- a/lib/gems/pending/metadata/linux/LinuxUtils.rb
+++ b/lib/gems/pending/metadata/linux/LinuxUtils.rb
@@ -177,16 +177,10 @@ module MiqLinux
     end
 
     def self.parse_openstack_status(lines)
-      lines.to_s.split("\n")
-        .slice_before do |line|
-        # get section for each OpenStack service
-        line.start_with?('== ') && line.end_with?(' ==')
-      end.map do |section|
+      lines.to_s.split("\n").reject{|t| t.include? "="}.group_by{|t| t.gsub(/openstack\-([a-z]+).*/i, '\1')}.map do |title, services|
         {
-          # OpenStack service section name
-          'name'     => section.first.delete('=').strip,
-          # get array of services
-          'services' => section[1..-1].map do |service_line|
+          'name'     => title.capitalize,
+          'services' => services.map do |service_line|
             # split service line by :, ( and ) and strip white space from results
             service_line.split(/[:\(\)]/).map(&:strip)
           end.map do |service|
@@ -197,9 +191,6 @@ module MiqLinux
             }
           end
         }
-      end.reject do |service|
-        # we omit Keystone users section
-        service['name'] == 'Keystone users'
       end
     end
   end

--- a/spec/metadata/linux/LinuxUtils_spec.rb
+++ b/spec/metadata/linux/LinuxUtils_spec.rb
@@ -4,32 +4,19 @@ describe MiqLinux::Utils do
   describe '#parse_openstack_status' do
     let(:text) do
       <<EOS
-== Nova services ==
 openstack-nova-api:                     active
 openstack-nova-cert:                    inactive  (disabled on boot)
 openstack-nova-compute:                 active
 openstack-nova-network:                 inactive  (disabled on boot)
 openstack-nova-scheduler:               active
 openstack-nova-conductor:               active
-== Glance services ==
 openstack-glance-api:                   active
 openstack-glance-registry:              active
-== Keystone service ==
 openstack-keystone:                     active
-== Horizon service ==
-openstack-dashboard:                    active
-== neutron services ==
-neutron-server:                         active
-neutron-dhcp-agent:                     active
-neutron-l3-agent:                       inactive  (disabled on boot)
-neutron-metadata-agent:                 inactive  (disabled on boot)
-neutron-openvswitch-agent:              active
-== Swift services ==
 openstack-swift-proxy:                  active
 openstack-swift-account:                active
 openstack-swift-container:              active
 openstack-swift-object:                 active
-== Ceilometer services ==
 openstack-ceilometer-api:               active
 openstack-ceilometer-central:           active
 openstack-ceilometer-compute:           inactive  (disabled on boot)
@@ -37,19 +24,10 @@ openstack-ceilometer-collector:         active
 openstack-ceilometer-alarm-notifier:    active
 openstack-ceilometer-alarm-evaluator:   active
 openstack-ceilometer-notification:      active
-== Heat services ==
 openstack-heat-api:                     active
 openstack-heat-api-cfn:                 active
 openstack-heat-api-cloudwatch:          active
 openstack-heat-engine:                  active
-== Support services ==
-mysqld:                                 inactive  (disabled on boot)
-openvswitch:                            active
-dbus:                                   active
-rabbitmq-server:                        active
-memcached:                              active
-== Keystone users ==
-Warning keystonerc not sourced
 EOS
     end
     let(:subject) { MiqLinux::Utils.parse_openstack_status(text) }
@@ -58,12 +36,11 @@ EOS
       is_expected.to be_a Array
     end
 
-    # we omit Keystone users section
-    it "should have 9 OpenStack services" do
-      expect(subject.count).to be_equal 9
+    it "should have 6 OpenStack services" do
+      expect(subject.count).to be_equal 6
     end
 
-    %w(Nova Glance Keystone Swift neutron Ceilometer Heat Support).map do |service|
+    %w(Nova Glance Keystone Swift Ceilometer Heat).map do |service|
       it "should have contain correct OpenStack #{service} service" do
         expect(subject.count { |service_hash| service_hash['name'].include?(service) }).to be_equal 1
       end


### PR DESCRIPTION
Openstack-status command which is used for getting Openstack services status on the Host during SSA was removed.

We need adapt to more generic command output.

This PR is part of https://bugzilla.redhat.com/show_bug.cgi?id=1434552 fix.