### PR TITLE
Use new postgres config scheme

### DIFF
--- a/lib/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/internal_database_configuration.rb
@@ -92,7 +92,7 @@ module ApplianceConsole
     def configure_postgres
       self.ssl = File.exist?(PostgresAdmin.certificate_location.join("postgres.key"))
 
-      copy_template "postgresql.conf.erb"
+      copy_template "postgresql.conf"
       copy_template "pg_hba.conf.erb"
       copy_template "pg_ident.conf"
     end

--- a/lib/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/internal_database_configuration.rb
@@ -130,6 +130,11 @@ module ApplianceConsole
       block_until_postgres_accepts_connections
     end
 
+    def restart_postgres
+      LinuxAdmin::Service.new(PostgresAdmin.service_name).restart
+      block_until_postgres_accepts_connections
+    end
+
     def block_until_postgres_accepts_connections
       loop do
         break if AwesomeSpawn.run("psql -U postgres -c 'select 1'").success?
@@ -166,6 +171,8 @@ module ApplianceConsole
         conn.exec("ALTER SYSTEM SET ssl TO on") if ssl
         conn.exec("ALTER SYSTEM SET shared_buffers TO #{shared_buffers}")
       end
+
+      restart_postgres
     end
   end
 end


### PR DESCRIPTION
This is a complementary PR to https://github.com/ManageIQ/manageiq-appliance/pull/116

This uses the newly named `postgresql.conf` file and makes dynamic changes to the configuration using `ALTER SYSTEM` SQL commands rather than relying on reference files and ERB.