### PR TITLE
Do not show IPv6 network-prefix-length unless there is IPv6 address

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -126,7 +126,7 @@ module ApplianceConsole
         summary_entry("Hostname", host),
         summary_entry("IPv4 Address", "#{ip}/#{mask}"),
         summary_entry("IPv4 Gateway", gw),
-        summary_entry("IPv6 Address", "#{eth0.address6}/#{eth0.prefix}"),
+        summary_entry("IPv6 Address", eth0.address6 ? "#{eth0.address6}/#{eth0.prefix}" : ''),
         summary_entry("IPV6 Gateway", eth0.gateway6),
         summary_entry("Primary DNS", dns1),
         summary_entry("Secondary DNS", dns2),


### PR DESCRIPTION
Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1439333 -- IPv6 address in appliance_console summary is "/24" despite not using IPv6