### PR TITLE
VDDK 6.5 Support

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "bunny",                   "~>2.1.0"
   s.add_runtime_dependency "excon",                   "~>0.40"
   s.add_runtime_dependency "ffi",                     "~>1.9.3"
-  s.add_runtime_dependency "ffi-vix_disk_lib",        "~>1.0.2"  # used by lib/VixDiskLib
+  s.add_runtime_dependency "ffi-vix_disk_lib",        "~>1.0.3"  # used by lib/VixDiskLib
   s.add_runtime_dependency "fog-openstack",           "=0.1.19"
   s.add_runtime_dependency "hawkular-client",         "=2.8.0"
   s.add_runtime_dependency "highline",                "~> 1.6.21" # Needed for the appliance_console


### PR DESCRIPTION
Upgrade ffi-vix_disk_lib gem to 1.03 to allow for VDDK 6.5 support.

This PR depends on the PR https://github.com/ManageIQ/ffi-vix_disk_lib/pull/9 and requires that it be pushed out to RubyGems.

@Fryguy @bdunne @roliveri Please review and merge after the above PR is available.