### PR TITLE
VDDK 6.5 Support.

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -32,7 +32,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "bunny",                   "~>2.1.0"
   s.add_runtime_dependency "excon",                   "~>0.40"
   s.add_runtime_dependency "ffi",                     "~>1.9.3"
-  s.add_runtime_dependency "ffi-vix_disk_lib",        "~>1.0.2"  # used by lib/VixDiskLib
+  s.add_runtime_dependency "ffi-vix_disk_lib",        "~>1.0.3"  # used by lib/VixDiskLib
   s.add_runtime_dependency "fog-openstack",           "=0.1.20"
   s.add_runtime_dependency "hawkular-client",         "=2.9.0"
   s.add_runtime_dependency "highline",                "~> 1.6.21" # Needed for the appliance_console


### PR DESCRIPTION
Add support for VDDK 6.5.  This requires ffi-vix_disk_lib gem 1.0.3.

@roliveri @Fryguy @bdunne This PR is dependent upon https://github.com/ManageIQ/ffi-vix_disk_lib/pull/9 being merged and updated in RubyGems.  Please review and merge when appropriate.  Thanks.
 Making this PR WIP until the above ffi-vix_disk_lib PR is pushed to RubyGems.  It has been merged.