### PR TITLE
[WIP] [DO NOT MERGE] Adding support for SCL Apache

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -22,6 +22,7 @@ require 'bcrypt'
 require 'linux_admin'
 require 'util/vmdb-logger'
 require 'util/postgres_admin'
+require 'util/miq_apache'
 require 'awesome_spawn'
 include HighLine::SystemExtensions
 
@@ -648,7 +649,7 @@ Static Network Configuration
             LinuxAdmin::Service.new("evmserverd").stop
             LinuxAdmin::Service.new("miqtop").stop
             LinuxAdmin::Service.new("miqvmstat").stop
-            LinuxAdmin::Service.new("httpd").stop
+            LinuxAdmin::Service.new(MiqApache.service_name).stop
             FileUtils.rm_rf(Dir.glob("/var/www/miq/vmdb/log/*.log*"))
             FileUtils.rm_rf(Dir.glob("/var/www/miq/vmdb/log/apache/*.log*"))
             Logging.logger.info("Logs cleaned and appliance rebooted by appliance console.")

--- a/lib/gems/pending/appliance_console/certificate_authority.rb
+++ b/lib/gems/pending/appliance_console/certificate_authority.rb
@@ -3,6 +3,7 @@ require 'tempfile'
 require 'appliance_console/principal'
 require 'appliance_console/certificate'
 require 'util/postgres_admin'
+require 'util/miq_apache'
 
 module ApplianceConsole
   # configure ssl certificates for postgres communication
@@ -110,7 +111,7 @@ module ApplianceConsole
       ).request
       if cert.complete?
         say "configuring apache to use new certs"
-        LinuxAdmin::Service.new("httpd").restart
+        LinuxAdmin::Service.new(MiqApache.service_name).restart
       end
       self.http = cert.status
     end

--- a/lib/gems/pending/appliance_console/external_httpd_authentication.rb
+++ b/lib/gems/pending/appliance_console/external_httpd_authentication.rb
@@ -79,8 +79,8 @@ module ApplianceConsole
     end
 
     def post_activation
-      say("\nRestarting httpd, if running ...")
-      httpd_service = LinuxAdmin::Service.new("httpd")
+      say("\nRestarting #{MiqApache.package_name}, if running ...")
+      httpd_service = LinuxAdmin::Service.new(MiqApache.service_name)
       httpd_service.restart if httpd_service.running?
 
       say("Restarting sssd and configure it to start on reboots ...")
@@ -137,7 +137,7 @@ module ApplianceConsole
     end
 
     def configure_httpd
-      say("Configuring httpd ...")
+      say("Configuring #{MiqApache.package_name} ...")
       configure_httpd_application
     end
 

--- a/lib/gems/pending/appliance_console/external_httpd_configuration.rb
+++ b/lib/gems/pending/appliance_console/external_httpd_configuration.rb
@@ -1,4 +1,5 @@
 require 'pathname'
+require 'miq_apache'
 
 module ApplianceConsole
   class ExternalHttpdAuthentication
@@ -15,8 +16,8 @@ module ApplianceConsole
       SSSD_CONFIG          = "/etc/sssd/sssd.conf".freeze
       PAM_CONFIG           = "/etc/pam.d/httpd-auth".freeze
       HTTP_KEYTAB          = "/etc/http.keytab".freeze
-      HTTP_REMOTE_USER     = "/etc/httpd/conf.d/manageiq-remote-user.conf".freeze
-      HTTP_EXTERNAL_AUTH   = "/etc/httpd/conf.d/manageiq-external-auth.conf".freeze
+      HTTP_REMOTE_USER     = "#{MiqApache.config_dir}/manageiq-remote-user.conf".freeze
+      HTTP_EXTERNAL_AUTH   = "#{MiqApache.config_dir}/manageiq-external-auth.conf".freeze
       HTTP_EXTERNAL_AUTH_TEMPLATE = "#{HTTP_EXTERNAL_AUTH}.erb".freeze
 
       GETSEBOOL_COMMAND    = "/usr/sbin/getsebool".freeze
@@ -66,11 +67,11 @@ module ApplianceConsole
       end
 
       def unconfigure_httpd
-        say("Unconfiguring httpd ...")
+        say("Unconfiguring #{MiqApache.package_name} ...")
         unconfigure_httpd_application
 
-        say("Restarting httpd ...")
-        LinuxAdmin::Service.new("httpd").restart
+        say("Restarting #{MiqApache.package_name} ...")
+        LinuxAdmin::Service.new(MiqApache.service_name).restart
       end
 
       def configure_httpd_application

--- a/lib/gems/pending/appliance_console/logfile_configuration.rb
+++ b/lib/gems/pending/appliance_console/logfile_configuration.rb
@@ -2,6 +2,7 @@ require 'linux_admin'
 require 'pathname'
 require 'fileutils'
 require 'util/miq-system.rb'
+require 'util/miq_apache'
 require 'appliance_console/logical_volume_management'
 require 'appliance_console/prompts'
 
@@ -105,13 +106,13 @@ module ApplianceConsole
     def start_evm
       say 'Starting EVM'
       LinuxAdmin::Service.new("evmserverd").enable.start
-      LinuxAdmin::Service.new("httpd").enable.start
+      LinuxAdmin::Service.new(MiqApache.service_name).enable.start
     end
 
     def stop_evm
       say 'Stopping EVM'
       LinuxAdmin::Service.new("evmserverd").stop
-      LinuxAdmin::Service.new("httpd").stop
+      LinuxAdmin::Service.new(MiqApache.service_name).stop
     end
   end
 end

--- a/lib/gems/pending/util/miq_apache/config.rb
+++ b/lib/gems/pending/util/miq_apache/config.rb
@@ -1,17 +1,57 @@
+require "yaml"
+
 module MiqApache
-  DEFAULT_ROOT_DIR = '/'
-  DEFAULT_SERVICE_NAME = 'httpd'
-  DEFAULT_PACKAGE_NAME = 'httpd'
+  DEFAULT = {
+    :scl          => false,
+    :package_name => "httpd",
+    :service_name => "httpd",
+    :root_dir     => "/",
+    :base_dir     => "/etc/httpd",
+    :config_dir   => "/etc/httpd/conf.d",
+    :apachectl    => "apachectl"
+  }.freeze
 
-  def self.root_dir
-    ENV.fetch('MIQ_APACHE_ROOT_DIR', DEFAULT_ROOT_DIR)
-  end
+  RAILS_ROOT ||= if File.exist?("/var/www/miq/vmdb")
+                   Pathname.new("/var/www/miq/vmdb")
+                 elsif defined?(Rails)
+                   Rails.root
+                 else
+                   gem_root = Gem::Specification.find_by_name("manageiq-gems-pending").gem_dir # rubocop:disable Rails/DynamicFindBy
+                   Pathname.new(File.expand_path(File.join(Pathname.new(gem_root), "../manageiq")))
+                 end.freeze
 
-  def self.service_name
-    ENV.fetch('MIQ_APACHE_SERVICE_NAME', DEFAULT_SERVICE_NAME)
+  def self.scl?
+    config[:scl] || DEFAULT[:scl]
   end
 
   def self.package_name
-    ENV.fetch('MIQ_APACHE_PACKAGE_NAME', DEFAULT_PACKAGE_NAME)
+    ENV.fetch('MIQ_APACHE_PACKAGE_NAME', config[:package_name] || DEFAULT[:package_name])
+  end
+
+  def self.service_name
+    ENV.fetch('MIQ_APACHE_SERVICE_NAME', config[:service_name] || DEFAULT[:service_name])
+  end
+
+  def self.root_dir
+    ENV.fetch('MIQ_APACHE_ROOT_DIR', config[:root_dir] || DEFAULT[:root_dir])
+  end
+
+  def self.base_dir
+    config[:base_dir] || DEFAULT[:base_dir]
+  end
+
+  def self.config_dir
+    config[:config_dir] || DEFAULT[:config_dir]
+  end
+
+  def self.apachectl
+    config[:apachectl] || DEFAULT[:apachectl]
+  end
+
+  def self.config
+    @_miq_apache_config ||= begin
+                              config_file = RAILS_ROOT.join("config/apache.yml")
+                              File.exist?(config_file) ? YAML.load_file(config_file) : {}
+                            end
   end
 end


### PR DESCRIPTION
Adding support for ManageIQ driven Apache configuration file config/yml

Extended MiqApache module to expose the directives with defaults
Updated Appliance Console configuration to use MiqApache module
Workaround for 2.4.18 httpd24-httpd configtest issue

PRs for ManageIQ SCL Apache Support:

- Gems Pending - https://github.com/ManageIQ/manageiq-gems-pending/pull/114
- ManageIQ - https://github.com/ManageIQ/manageiq/pull/14693
- Appliance - https://github.com/ManageIQ/manageiq-appliance/pull/117
- Appliance Build - https://github.com/ManageIQ/manageiq-appliance-build/pull/208