### PR TITLE
Disable cloud-init network re-config on network updates

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -185,7 +185,7 @@ To modify the configuration, use a web browser to access the management page.
             eth0.enable_dhcp6 if ipv6
             eth0.save
 
-            open(CLOUD_INIT_NETWORK_CONFIG_FILE, "w") { |f| f << CLOUD_INIT_DISABLE_NETWORK_CONFIG }
+            File.write(CLOUD_INIT_NETWORK_CONFIG_FILE, CLOUD_INIT_DISABLE_NETWORK_CONFIG)
             say("\nAfter completing the appliance configuration, please restart #{I18n.t("product.name")} server processes.")
             press_any_key
           end
@@ -236,7 +236,7 @@ Static Network Configuration
               next
             end
 
-            open(CLOUD_INIT_NETWORK_CONFIG_FILE, "w") { |f| f << CLOUD_INIT_DISABLE_NETWORK_CONFIG }
+            File.write(CLOUD_INIT_NETWORK_CONFIG_FILE, CLOUD_INIT_DISABLE_NETWORK_CONFIG)
             say("\nAfter completing the appliance configuration, please restart #{I18n.t("product.name")} server processes.")
             press_any_key
           end
@@ -287,7 +287,7 @@ Static Network Configuration
               next
             end
 
-            open(CLOUD_INIT_NETWORK_CONFIG_FILE, "w") { |f| f << CLOUD_INIT_DISABLE_NETWORK_CONFIG }
+            File.write(CLOUD_INIT_NETWORK_CONFIG_FILE, CLOUD_INIT_DISABLE_NETWORK_CONFIG)
             say("\nAfter completing the appliance configuration, please restart #{I18n.t("product.name")} server processes.")
             press_any_key
           end

--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -93,6 +93,8 @@ RE_DELLOGS  = "Restart and Clean Logs".freeze
 RE_OPTIONS  = [RE_RESTART, RE_DELLOGS, ApplianceConsole::CANCEL].freeze
 
 NETWORK_INTERFACE = "eth0".freeze
+CLOUD_INIT_NETWORK_CONFIG_FILE = "/etc/cloud/cloud.cfg.d/99_miq_disable_network_config.cfg".freeze
+CLOUD_INIT_DISABLE_NETWORK_CONFIG = "network: {config: disabled}\n".freeze
 
 module ApplianceConsole
   eth0 = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE)
@@ -183,6 +185,7 @@ To modify the configuration, use a web browser to access the management page.
             eth0.enable_dhcp6 if ipv6
             eth0.save
 
+            open(CLOUD_INIT_NETWORK_CONFIG_FILE, "w") { |f| f << CLOUD_INIT_DISABLE_NETWORK_CONFIG }
             say("\nAfter completing the appliance configuration, please restart #{I18n.t("product.name")} server processes.")
             press_any_key
           end
@@ -233,6 +236,7 @@ Static Network Configuration
               next
             end
 
+            open(CLOUD_INIT_NETWORK_CONFIG_FILE, "w") { |f| f << CLOUD_INIT_DISABLE_NETWORK_CONFIG }
             say("\nAfter completing the appliance configuration, please restart #{I18n.t("product.name")} server processes.")
             press_any_key
           end
@@ -283,6 +287,7 @@ Static Network Configuration
               next
             end
 
+            open(CLOUD_INIT_NETWORK_CONFIG_FILE, "w") { |f| f << CLOUD_INIT_DISABLE_NETWORK_CONFIG }
             say("\nAfter completing the appliance configuration, please restart #{I18n.t("product.name")} server processes.")
             press_any_key
           end


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1439373

_**The Problem:**_

The appliance_console writes user chosen network settings to the network interface configuration file: /etc/sysconfig/network-scripts/ifcfg-eth0

On reboot newer versions of cloud-init reset the network configuration to "BOOTPROTO=dhcp" by rewriting the same file.

_**The Solution**_

This PR prevents cloud-init from reseting the network configuration when the appliance_console is used to configure it.  

To do this the appliance_console will create the file: /etc/cloud/cloud.cfg.d/99_miq_disable_network_config.cfg with the proper
cloud-init directive instructing cloud-init to not modify the network interface configuration file.

Given the very precise name, of "/etc/cloud/cloud.cfg.d/99_miq_disable_network_config.cfg" it is unlikely that something else will also create it. Therefor it is considered unnecessary for the appliance_console to checking for it's existence prior to creating it.

_**To Test:**_

1. Launch a new appliance VM
2. use appliance_console to configure a static network address
3. reboot the VM
4. Confirm the address configured in step 2. persists 
