### PR TITLE
Typo: Report ipv6 prefix instead of ipv4 prefix

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -128,7 +128,7 @@ module ApplianceConsole
         summary_entry("Hostname", host),
         summary_entry("IPv4 Address", "#{ip}/#{mask}"),
         summary_entry("IPv4 Gateway", gw),
-        summary_entry("IPv6 Address", eth0.address6 ? "#{eth0.address6}/#{eth0.prefix}" : ''),
+        summary_entry("IPv6 Address", eth0.address6 ? "#{eth0.address6}/#{eth0.prefix6}" : ''),
         summary_entry("IPV6 Gateway", eth0.gateway6),
         summary_entry("Primary DNS", dns1),
         summary_entry("Secondary DNS", dns2),


### PR DESCRIPTION
Follow up on https://github.com/ManageIQ/manageiq-gems-pending/pull/111

https://bugzilla.redhat.com/show_bug.cgi?id=1439333

@miq-bot add_label fine/yes