### PR TITLE
Upgrade nokogiri to 1.7.x

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -48,7 +48,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "more_core_extensions",    "~>3.2"
   s.add_runtime_dependency "net-scp",                 "~>1.2.1"
   s.add_runtime_dependency "net-sftp",                "~>2.1.2"
-  s.add_runtime_dependency "nokogiri",                "~>1.6.8"
+  s.add_runtime_dependency "nokogiri",                "~>1.7.1"
   s.add_runtime_dependency "openscap",                "~>0.4.3"
   s.add_runtime_dependency "ovirt",                   "~>0.15.1"
   s.add_runtime_dependency "parallel",                "~>1.9" # For OvirtInventory


### PR DESCRIPTION
This PR upgrades the Nokogiri dependency from 1.6.x to 1.7.x. This addresses complaints from Hakiri which indicated that there have been security patches to nokogiri/libxml2.

See CVE-2016-4658 for details:

http://cve.mitre.org/cgi-bin/cvename.cgi?name=cve-2016-4658