### PR TITLE
#121 Fix for RollupFix within patch strings on windows VMs

### DIFF
--- a/lib/gems/pending/metadata/util/win32/Win32Software.rb
+++ b/lib/gems/pending/metadata/util/win32/Win32Software.rb
@@ -154,10 +154,27 @@ module MiqWin32
         hotfix = {}
         reg_node.each_element do |e|
           if e.attributes[:keyname][0, 8] == 'Package_'
-
+            # Expected pattern: Package_for_KBxxx_RTM~xxxx
+            
             # Get the hotfix id (KB #) out of the keyname
             package = e.attributes[:keyname].split("_")
-            hotfix_id = (package[2][0, 2] == 'KB') ? package[2] : package[3]
+            
+            # If the package identifier starts with KB, use this
+            # otherwise grab the ID from the end of the string (if it's long enough)
+            hotfix_id = nil
+            if (package[2][0, 2] == 'KB')
+              hotfix_id = package[2]
+            elsif package.size >= 4
+              hotfix_id = package[3]
+            else
+              # Unknown package ID pattern, print this out
+              str = ''
+              e.write(str)
+              $log.warn "Win32Software::initialize - Can't determine patch element's hotfix id: #{str}"
+            end
+            # don't add this package if the ID is nil
+            next if hotfix_id.nil?
+            
             hotfix_id = hotfix_id.split('~')[0]
 
             unless hotfix.key?(hotfix_id)


### PR DESCRIPTION
Fix for SmartState Analysis failing on "RollupFix" packages on Windows 2012 VMs.

Based on testing the KB numbers contained in the RollupFix are present in other registry entries so (currently) safe to ignore these and print a warning.

This now allows patches and applications to be parsed successfully.