### PR TITLE
Add a webtreemap view for require_with_logging

### DIFF
--- a/tools/requires_log_to_webtreemap.rb
+++ b/tools/requires_log_to_webtreemap.rb
@@ -1,0 +1,49 @@
+if ARGV.length != 2
+  puts "Usage: #{$0} /path/to/requires.log /path/to/webtreemap"
+  puts
+  puts "This tool uses webtreemap, which can be obtained from https://github.com/evmar/webtreemap"
+  exit 1
+end
+
+require 'active_support/all'
+
+requires_file, webtreemap_dir = ARGV
+
+def parse_line(line)
+  match = line.match(/^(?<indent>[0-9 ]{3})  ..  (?:\| )*(?<location>[^(]+)(?: \((?<metric>[-0-9.]+)\))?$/)
+  return {} unless match
+  {
+    :indent   => match[:indent].to_i,
+    :location => match[:location].strip,
+  }.tap do |h|
+    h[:metric] = match[:metric].to_f if match[:metric]
+  end
+end
+
+nestings = []
+current_indent = -1
+
+File.open(requires_file) do |f|
+  f.each_line do |line|
+    line = parse_line(line)
+
+    if line[:indent] > current_indent
+      current_indent += 1
+      nestings << []
+    elsif line[:indent] < current_indent
+      current_indent -= 1
+      children = nestings.pop
+      dot_metrics = line[:metric] - children.map { |c| c[:data]["$area"] }.sum
+      children << {:name => ". (#{dot_metrics})", :data => {"$area" => dot_metrics}}
+      nestings.last << {:name => "#{line[:location]} (#{line[:metric]})", :data => {"$area" => line[:metric]}, :children => children}
+    elsif line[:metric]
+      nestings.last << {:name => "#{line[:location]} (#{line[:metric]})", :data => {"$area" => line[:metric]}}
+    end
+  end
+end
+
+children = nestings.pop
+result = {:name => "Total", :data => {"$area" => children.map { |c| c[:data]["$area"] }.sum}, :children => children}
+
+webtreemap_file = File.join(webtreemap_dir, "demo/demo.json")
+File.write(webtreemap_file, "var kTree=#{result.to_json}")


### PR DESCRIPTION
Additionally, add support for metrics based on allocations and memory.

This tool uses webtreemap, which can be obtained from https://github.com/evmar/webtreemap.  See the [demo](http://evmar.github.io/webtreemap/) (NOTE: This PR is old and is using v1, so would have to be upgraded to use v2)

After using require_with_logging to obtain a log file, then requires_log_to_webtreemap.rb can be used to parse that file into the webtreemap.  Here is an example of what webtreemap looks like against current ManageIQ, at boot, profiling allocations:

<img width="1792" alt="manageiq - master allocations by require 2017-04-17 18-11-25" src="https://cloud.githubusercontent.com/assets/52120/25106772/536c473a-2399-11e7-9944-d57be0708389.png">

@jrafanie Please review.
