### PR TITLE
Do not allow to enter empty passwords when configuring DB

### DIFF
--- a/lib/gems/pending/appliance_console/database_configuration.rb
+++ b/lib/gems/pending/appliance_console/database_configuration.rb
@@ -120,17 +120,22 @@ module ApplianceConsole
       self.username = just_ask("username", username) unless local?
       count = 0
       loop do
-        count += 1
-        password1   = ask_for_password_or_none("database password on #{host}", password)
+        password1 = ask_for_password("database password on #{host}", password)
         # if they took the default, just bail
         break if (password1 == password)
-        password2   = ask_for_password("database password again")
+        
+        if password1.strip.length == 0
+          say("\nPassword can not be empty, please try again")
+          next
+        end
+        password2 = ask_for_password("database password again")
         if password1 == password2
           self.password = password1
           break
-        elsif count > 1 # only reprompt password once
-          raise ArgumentError, "passwords did not match"
+        elsif count > 0 # only reprompt password once
+          raise RuntimeError, "passwords did not match"
         else
+          count += 1
           say("\nThe passwords did not match, please try again")
         end
       end

--- a/lib/gems/pending/appliance_console/database_replication.rb
+++ b/lib/gems/pending/appliance_console/database_replication.rb
@@ -100,7 +100,7 @@ Replication Server Configuration
       count = 0
       loop do
         count += 1
-        password1 = ask_for_password_or_none("cluster database password", database_password)
+        password1 = ask_for_password("cluster database password", database_password)
         # if they took the default, just bail
         break if password1 == database_password
         password2 = ask_for_password("cluster database password")
@@ -108,7 +108,7 @@ Replication Server Configuration
           self.database_password = password1
           break
         elsif count > 1 # only reprompt password once
-          raise ArgumentError, "passwords did not match"
+          raise RuntimeError, "passwords did not match"
         else
           say("\nThe passwords did not match, please try again")
         end

--- a/spec/appliance_console/database_configuration_spec.rb
+++ b/spec/appliance_console/database_configuration_spec.rb
@@ -211,7 +211,14 @@ describe ApplianceConsole::DatabaseConfiguration do
     it "should raise an error if passwords do not match twice" do
       expect(subject).to receive(:just_ask).with(/password/i, anything).twice.and_return(*%w(pass1 pass2 pass3 pass4))
 
-      expect { subject.ask_for_database_credentials }.to raise_error(ArgumentError, "passwords did not match")
+      expect { subject.ask_for_database_credentials }.to raise_error(RuntimeError, "passwords did not match")
+    end
+
+    it "does not allow empty password" do
+      expect(subject).to receive(:just_ask).and_return(" ")
+      expect(subject).to receive(:say).with("\nPassword can not be empty, please try again")
+      expect(subject).to receive(:loop).and_yield
+      subject.ask_for_database_credentials
     end
   end
 

--- a/spec/appliance_console/database_replication_spec.rb
+++ b/spec/appliance_console/database_replication_spec.rb
@@ -33,8 +33,7 @@ describe ApplianceConsole::DatabaseReplication do
     it "should store the newly supplied values" do
       expect(subject).to receive(:just_ask).with(/ name/i, "defaultdatabasename").and_return("newdatabasename")
       expect(subject).to receive(:just_ask).with(/ user/i, "defaultuser").and_return("newuser")
-      expect(subject).to receive(:ask_for_password_or_none).with(/password/i, nil).and_return("newpassword")
-      expect(subject).to receive(:ask_for_password).with(/password/i).and_return("newpassword")
+      expect(subject).to receive(:ask_for_password).with(/password/i, any_args).twice.and_return("newpassword")
       expect(subject)
         .to receive(:ask_for_ip_or_hostname).with(/primary.*hostname/i, "defaultprimary").and_return("newprimary")
 


### PR DESCRIPTION
We need to check for empty passwords when creating local internal DB (from appliance console)

https://bugzilla.redhat.com/show_bug.cgi?id=1443689


