### PR TITLE
Check for existing nodes before attempting registration

### DIFF
--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -13,7 +13,7 @@ module ApplianceConsole
     REGISTER_CMD    = 'repmgr standby register'.freeze
     REPMGRD_SERVICE = 'rh-postgresql95-repmgr'.freeze
 
-    attr_accessor :disk, :standby_host, :run_repmgrd_configuration
+    attr_accessor :disk, :standby_host, :run_repmgrd_configuration, :resync_data
 
     def initialize
       self.cluster_name      = nil
@@ -23,11 +23,13 @@ module ApplianceConsole
       self.database_password = nil
       self.primary_host      = nil
       self.standby_host      = LinuxAdmin::NetworkInterface.new(NETWORK_INTERFACE).address
+      self.resync_data       = false
     end
 
     def ask_questions
       clear_screen
       say("Establish Replication Standby Server\n")
+      return false if !data_dir_empty? && !confirm_data_resync
       self.disk = ask_for_disk("Standby database disk")
       ask_for_unique_cluster_node_number
       ask_for_database_credentials
@@ -60,9 +62,8 @@ module ApplianceConsole
     def activate
       say("Configuring Replication Standby Server...")
       initialize_postgresql_disk if disk
-      PostgresAdmin.prep_data_directory
-      data_dir_empty? &&
-        generate_cluster_name &&
+      PostgresAdmin.prep_data_directory if disk || resync_data
+      generate_cluster_name &&
         create_config_file(standby_host) &&
         clone_standby_server &&
         start_postgres &&
@@ -72,14 +73,17 @@ module ApplianceConsole
     end
 
     def data_dir_empty?
-      return true if Dir[PostgresAdmin.data_directory.join("*")].empty?
+      Dir[PostgresAdmin.data_directory.join("*")].empty?
+    end
+
+    def confirm_data_resync
       Logging.logger.info("Appliance database found under: #{PostgresAdmin.data_directory}")
       say("")
       say("Appliance database found under: #{PostgresAdmin.data_directory}")
       say("Replication standby server can not be configured if the database already exists")
-      say("Remove the existing database before configuring as a standby server")
-      say("")
-      false
+      say("Would you like to remove the existing database before configuring as a standby server?")
+      say("  WARNING: This is destructive. This will remove all previous data from this server")
+      self.resync_data = ask_yn?("Continue")
     end
 
     def clone_standby_server

--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -93,8 +93,7 @@ class PostgresAdmin
     # initdb will fail if the database directory is not empty or not owned by the PostgresAdmin.user
     FileUtils.mkdir(PostgresAdmin.data_directory) unless Dir.exist?(PostgresAdmin.data_directory)
     FileUtils.chown_R(PostgresAdmin.user, PostgresAdmin.user, PostgresAdmin.data_directory)
-    FileUtils.rm_rf(PostgresAdmin.data_directory.join("pg_log"))
-    FileUtils.rm_rf(PostgresAdmin.data_directory.join("lost+found"))
+    FileUtils.rm_rf(PostgresAdmin.data_directory.children.map(&:to_s))
   end
 
   def self.backup(opts)


### PR DESCRIPTION
This will allow failed primary database servers to be more easily added back to the cluster as standby servers.

When there is existing data in the data directory the console will now prompt the user about if they would like to remove the existing data before continuing with the setup (rather than just failing outright).

Additionally, this implements a check during the "ask questions" phase of setting up a standby server which will inform the user if they are trying to use a node number which is already assigned to a node record.

Before this change the initial clone and replication setup would succeed, but the registration would fail if a user tried to re-use a node number (from a previously failed node, for example). This would leave you in a state where the new standby server is started and is replicating from a new replication slot on the primary, but cannot join the repmgr cluster.

This can be avoided by registering with the `--force` flag, but we don't really want to do that unconditionally so we have to connect to the primary to determine if the requested node number is in use *before* doing the clone then prompt the user for confirmation.

This fixes a number of BZs:

https://bugzilla.redhat.com/show_bug.cgi?id=1426718 - Make the process of reintroducing a failed HA node more user-friendly
https://bugzilla.redhat.com/show_bug.cgi?id=1426769 - After reintroducing a failed primary node, there are old replication slots left on the "new" node
https://bugzilla.redhat.com/show_bug.cgi?id=1442911 - In new db master node, pg_xlog directory got fulled