### PR TITLE
Use version 0.16.0 of the 'ovirt' gem

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-sftp",                "~>2.1.2"
   s.add_runtime_dependency "nokogiri",                "~>1.7.1"
   s.add_runtime_dependency "openscap",                "~>0.4.3"
-  s.add_runtime_dependency "ovirt",                   "~>0.15.1"
+  s.add_runtime_dependency "ovirt",                   "~>0.16.0"
   s.add_runtime_dependency "pg",                      "~>0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~>0.1.0"
   s.add_runtime_dependency "psych",                   "~>2.0.12"


### PR DESCRIPTION
The new version of the gem fixes the following problems:

  Add VM FQDN to guest_info
  https://bugzilla.redhat.com/1417965

  Fix handling of version 4.y in Vm.attach_payload
  https://bugzilla.redhat.com/1441746