### PR TITLE
Update to linux_admin to support old LinuxAdmin.run interface

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -40,7 +40,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"
   s.add_runtime_dependency "iniparse"
   s.add_runtime_dependency "kubeclient",              "=2.3.0"
-  s.add_runtime_dependency "linux_admin",             "~>0.20.0"
+  s.add_runtime_dependency "linux_admin",             "~>0.20.1"
   s.add_runtime_dependency "linux_block_device",      "~>0.2.1"
   s.add_runtime_dependency "log4r",                   "=1.1.8"
   s.add_runtime_dependency "memoist",                 "~>0.15.0"


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1443739

It was removed but should have gone through a deprecation cycle.
Existing user automate scripts could be using this previously removed
interface.

See: https://github.com/ManageIQ/linux_admin/pull/186