### PR TITLE
Fix undefined vmConfig method for MiqOpenstackeImage and shorter OS device signature.

### DIFF
--- a/lib/gems/pending/metadata/MIQExtract/MIQExtract.rb
+++ b/lib/gems/pending/metadata/MIQExtract/MIQExtract.rb
@@ -158,10 +158,10 @@ class MIQExtract
   end
 
   def getVMConfig(_c)
-    # Get VM config in XML format
-    config_xml = @target.vmConfig.toXML(true, @target)
-
     begin
+      # Get VM config in XML format
+      config_xml = @target.vmConfig.toXML(true, @target)
+
       # Log snapshot data for diagnostic purposes
       config_xml.find_each("//vm/snapshots") do |s|
         formattedXml = ""

--- a/lib/gems/pending/metadata/util/win32/system_path_win.rb
+++ b/lib/gems/pending/metadata/util/win32/system_path_win.rb
@@ -95,7 +95,7 @@ module Win32
       # Decode disk signature
       unless result[:os_device].nil?
         d = result[:os_device].split(',')
-        result[:disk_sig] = (d[59] + d[58] + d[57] + d[56]).to_i(16)
+        result[:disk_sig] = (d[59] + d[58] + d[57] + d[56]).to_i(16) if d.size > 60
       end
       result
     end


### PR DESCRIPTION
Fix the following corner cases:
1. OS device name is shorted than expect;
2. Both MiqOpenstackImage and MiqOpenstaceInstance don't have vmConfig defined;

https://bugzilla.redhat.com/show_bug.cgi?id=1372672