### PR TITLE
Move 'ovirt' version dependency to provider plugin

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-sftp",                "~>2.1.2"
   s.add_runtime_dependency "nokogiri",                "~>1.7.1"
   s.add_runtime_dependency "openscap",                "~>0.4.3"
-  s.add_runtime_dependency "ovirt",                   "~>0.15.1"
+  s.add_runtime_dependency "ovirt"                    # Version specified by manageiq-providers-ovirt.  TODO: remove direct dependencies on 'ovirt'.
   s.add_runtime_dependency "pg",                      "~>0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~>0.1.0"
   s.add_runtime_dependency "psych",                   "~>2.0.12"


### PR DESCRIPTION
Specifying a "~>x.y.z" on 'ovirt' in both manageiq-gems-pending and manageiq-providers-ovirt makes it really hard to not break Travis for at least a short on one of many repos.  It's also painful for developers who try to `bundle update` while there are conflicting dependencies.  This happens frequently and it is often merged in one repo, but then tests fail in the other repo leaving us in a state where you can not `bundle` for an unreasonable amount of time.
Since I see manageiq-gems-pending as technical debt, I'm loosening the requirement here and giving control to the provider plugin.  Eventually all dependencies on ovirt in this repo should be removed anyway.