### PR TITLE
Move 'azure-armrest' version dependency to provider plugin

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -25,7 +25,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",           ">= 5.0", "< 5.1"
   s.add_runtime_dependency "addressable",             "~> 2.4"
   s.add_runtime_dependency "awesome_spawn",           "~> 1.4"
-  s.add_runtime_dependency "azure-armrest",           "~> 0.7.1"
+  s.add_runtime_dependency "azure-armrest"            # Version specified by manageiq-providers-azure.  TODO: remove direct dependencies on 'azure-armrest'.
   s.add_runtime_dependency "bcrypt",                  "~> 3.1.10"
   s.add_runtime_dependency "binary_struct",           "~> 2.1"
   s.add_runtime_dependency "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/


### PR DESCRIPTION
Following the pattern set by #133 this moves the version requirement on 'azure-armrest' to 'manageiq-providers-azure'.

cc @djberg96 