### PR TITLE
Remove unnecessary dependency

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -56,7 +56,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "psych",                   "~>2.0.12"
   s.add_runtime_dependency "rake",                    ">=11.0"
   s.add_runtime_dependency "rbvmomi",                 "~>1.9.4"
-  s.add_runtime_dependency "rest-client",             "~>2.0.0"
   s.add_runtime_dependency "rubyzip",                 "~>1.2.0"
   s.add_runtime_dependency "rufus-lru",               "~>1.0.3"
   s.add_runtime_dependency "sys-proctable",           "~>1.1.3"


### PR DESCRIPTION
Nothing in manageiq-gems-pending uses it and I don't see any reason to lock it down here.

As far as I know it is used and depended on by:
azure-armrest
foreman_api_client
hawkular-client
image-inspector-client
kubeclient
ovirt