### PR TITLE
:scissors: :fire: zip-zip isn't required anywhere in manageiq or manageiq-gems-pending

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -65,7 +65,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "uuidtools",               "~>2.1.3"
   s.add_runtime_dependency "winrm",                   "~>2.1"
   s.add_runtime_dependency "winrm-elevated",          "~>1.0.1"
-  s.add_runtime_dependency "zip-zip",                 "~>0.3.0"
 
   s.add_development_dependency "camcorder"
   s.add_development_dependency "rspec",        "~>3.5.0"


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq/pull/14881 and https://github.com/ManageIQ/manageiq-automation_engine/pull/10