### PR TITLE
Bump version of hawkular-client gem to 3.0.1

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "ffi",                     "~>1.9.3"
   s.add_runtime_dependency "ffi-vix_disk_lib",        "~>1.0.3"  # used by lib/VixDiskLib
   s.add_runtime_dependency "fog-openstack",           "=0.1.20"
-  s.add_runtime_dependency "hawkular-client",         "=2.9.0"
+  s.add_runtime_dependency "hawkular-client",         "=3.0.1"
   s.add_runtime_dependency "highline",                "~> 1.6.21" # Needed for the appliance_console
   s.add_runtime_dependency "httpclient",              "~>2.7.1"
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"


### PR DESCRIPTION
Version 0.36 of Hawkular services has been released with a new inventory
implementation. Client gem version 3.0.1 is the one supporting the new
release.

@miq-bot add_label gem changes