### PR TITLE
Remove the pglogical extension before attempting a database restore

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -118,8 +118,11 @@ class PostgresAdmin
         pglogical.subscription subs,
         LATERAL pglogical.drop_subscription(subs.sub_name)
     SQL
+    runcmd("psql", opts, :command => <<-SQL)
+      DROP EXTENSTION pglogical CASCADE
+    SQL
   rescue AwesomeSpawn::CommandResultError
-    $log.info("MIQ(#{name}.#{__method__}) Ignoring failure to remove pglogical subscriptions ...")
+    $log.info("MIQ(#{name}.#{__method__}) Ignoring failure to remove pglogical before restore ...")
   end
 
   def self.backup_compress_with_gzip


### PR DESCRIPTION
In newer versions of pglogical the manager process continues running
even if there are no subscriptions on a node. This process holds open
a connection that prevents us from dropping the database when we want
to run a restore. This change removes that connection by completely
removing the extension before the restore runs.

https://bugzilla.redhat.com/show_bug.cgi?id=1444993