### PR TITLE
Stop the postgres and repmgr services before configuring a standby

### DIFF
--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -62,6 +62,8 @@ module ApplianceConsole
 
     def activate
       say("Configuring Replication Standby Server...")
+      stop_postgres
+      stop_repmgrd
       initialize_postgresql_disk if disk
       PostgresAdmin.prep_data_directory if disk || resync_data
       generate_cluster_name &&
@@ -102,6 +104,11 @@ module ApplianceConsole
       true
     end
 
+    def stop_postgres
+      LinuxAdmin::Service.new(PostgresAdmin.service_name).stop
+      true
+    end
+
     def register_standby_server
       run_repmgr_command(REGISTER_CMD, :force => nil)
     end
@@ -114,6 +121,11 @@ module ApplianceConsole
       Logging.logger.error(message)
       say(message)
       false
+    end
+
+    def stop_repmgrd
+      LinuxAdmin::Service.new(REPMGRD_SERVICE).stop
+      true
     end
 
     def node_number_valid?

--- a/spec/appliance_console/database_replication_standby_spec.rb
+++ b/spec/appliance_console/database_replication_standby_spec.rb
@@ -117,6 +117,8 @@ describe ApplianceConsole::DatabaseReplicationStandby do
 
   context "#activate" do
     before do
+      expect(subject).to receive(:stop_postgres)
+      expect(subject).to receive(:stop_repmgrd)
       expect(subject).to receive(:generate_cluster_name).and_return(true)
       expect(subject).to receive(:create_config_file).and_return(true)
       expect(subject).to receive(:clone_standby_server).and_return(true)
@@ -245,6 +247,16 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     end
   end
 
+  context "#stop_postgres" do
+    it "should stop postgres and return true" do
+      service = double("PostgresService", :service => nil)
+      expect(LinuxAdmin::Service).to receive(:new).and_return(service)
+      expect(service).to receive(:stop)
+
+      expect(subject.stop_postgres).to be_truthy
+    end
+  end
+
   context "#start_repmgrd" do
     it "starts and enables repmgrd" do
       service = double(SPEC_NAME)
@@ -261,6 +273,16 @@ describe ApplianceConsole::DatabaseReplicationStandby do
       expect(service).to receive(:enable).and_return(service)
       expect(service).to receive(:start).and_raise(AwesomeSpawn::CommandResultError.new("", result))
       expect(subject.start_repmgrd).to be false
+    end
+  end
+
+  context "#stop_repmgrd" do
+    it "stops the repmgrd service" do
+      service = double("RepmgrdService")
+      expect(LinuxAdmin::Service).to receive(:new).and_return(service)
+      expect(service).to receive(:stop)
+
+      expect(subject.stop_repmgrd).to be true
     end
   end
 


### PR DESCRIPTION
This ensures that we will not error out in the "reconfigure" case.

In this case the standby server is configured successfully and we
go through the process of configuring a standby server again. Before
this change we would fail because the running PG server would be
using the replication slot that we wanted to replace.

This error would leave the primary server with a replication slot
and would remove the data from the standby server.

https://bugzilla.redhat.com/show_bug.cgi?id=1445841