### PR TITLE
Add vmConfig & volumeManager into SUPPORT_METHODS

### DIFF
--- a/lib/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
+++ b/lib/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackImage.rb
@@ -7,7 +7,7 @@ class MiqOpenStackImage
 
   attr_reader :vmConfigFile
 
-  SUPPORTED_METHODS = [:rootTrees, :extract, :diskInitErrors]
+  SUPPORTED_METHODS = [:rootTrees, :extract, :diskInitErrors, :vmConfig, :volumeManager]
 
   def initialize(image_id, args)
     @image_id     = image_id

--- a/lib/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
+++ b/lib/gems/pending/OpenStackExtract/MiqOpenStackVm/MiqOpenStackInstance.rb
@@ -12,7 +12,7 @@ class MiqOpenStackInstance
 
   attr_reader :vmConfigFile
 
-  SUPPORTED_METHODS = [:rootTrees, :extract, :diskInitErrors]
+  SUPPORTED_METHODS = [:rootTrees, :extract, :diskInitErrors, :vmConfig, :volumeManager]
 
   def initialize(instance_id, openstack_handle)
     @instance_id      = instance_id


### PR DESCRIPTION
Enable MiqOpenstackeImage/MiqOpenstackInstance to call vmConfig and volumeManager, so SSA will works properly without hanging.

https://bugzilla.redhat.com/show_bug.cgi?id=1372672