### PR TITLE
Fix Openstack Metrics resource_id field

### DIFF
--- a/lib/gems/pending/openstack/openstack_handle/metric_delegate.rb
+++ b/lib/gems/pending/openstack/openstack_handle/metric_delegate.rb
@@ -17,6 +17,7 @@ module OpenstackHandle
     def list_meters(filters)
       data = []
       filters.each do |filter|
+        filter['field'] = 'resource_id' if filter['field'] == 'metadata.resource_id'
         next if filter['field'] == 'metadata.instance_id'
         raise "Unexpected Metric filter \"#{filter['field']}\"" unless filter['field'] == 'resource_id'
         res = resources.find_by_id(filter['value'])


### PR DESCRIPTION
Openstack Gnocchi metrics store in some cases resource_id under
metadata, which changes its name to metadata.resource_id.
Updating code to handle it in same way.

https://bugzilla.redhat.com/show_bug.cgi?id=1443903