### PR TITLE
hawkular-client isn't referenced anywhere in manageiq-gems-pending

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -34,7 +34,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "ffi",                     "~>1.9.3"
   s.add_runtime_dependency "ffi-vix_disk_lib",        "~>1.0.3"  # used by lib/VixDiskLib
   s.add_runtime_dependency "fog-openstack",           "=0.1.20"
-  s.add_runtime_dependency "hawkular-client",         "~>3.0.2"
   s.add_runtime_dependency "highline",                "~> 1.6.21" # Needed for the appliance_console
   s.add_runtime_dependency "httpclient",              "~>2.7.1"
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"


### PR DESCRIPTION
Depends on https://github.com/ManageIQ/manageiq-providers-hawkular/pull/15 and https://github.com/ManageIQ/manageiq-providers-kubernetes/pull/13