### PR TITLE
Add method to return VM Hardware

### DIFF
--- a/lib/gems/pending/VMwareWebService/MiqVimVm.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimVm.rb
@@ -609,6 +609,15 @@ class MiqVimVm
     waitForTask(taskMor)
   end
 
+  def getHardware
+    getProp("config.hardware").try(:fetch_path, "config", "hardware") || {}
+  end
+
+  def getScsiControllers(hardware = nil)
+    hardware ||= getHardware()
+    hardware["device"].to_a.select { |dev| VIRTUAL_SCSI_CONTROLLERS.include?(dev.xsiType) }
+  end
+
   def getMemory
     getProp("summary.config.memorySizeMB")["summary"]["config"]["memorySizeMB"].to_i
   end

--- a/lib/gems/pending/VMwareWebService/MiqVimVm.rb
+++ b/lib/gems/pending/VMwareWebService/MiqVimVm.rb
@@ -862,12 +862,14 @@ class MiqVimVm
   # Find a SCSI controller and
   # return its key and next available unit number.
   #
-  def available_scsi_units
+  def available_scsi_units(hardware = nil)
     scsi_units       = []
     all_unit_numbers = [*0..MAX_SCSI_DEVICES]
 
-    devices = getProp("config.hardware")["config"]["hardware"]["device"]
-    scsi_controllers = devices.select { |dev| VIRTUAL_SCSI_CONTROLLERS.include?(dev.xsiType) }
+    hardware ||= getHardware()
+
+    devices = hardware["device"]
+    scsi_controllers = getScsiControllers(hardware)
 
     scsi_controllers.sort_by { |s| s["key"].to_i }.each do |scsi_controller|
       # Skip if all controller units are populated
@@ -895,12 +897,10 @@ class MiqVimVm
     scsi_units
   end # def available_scsi_units
 
-  def available_scsi_buses
+  def available_scsi_buses(hardware = nil)
     scsi_controller_bus_numbers = [*0..MAX_SCSI_CONTROLLERS - 1]
 
-    devices = getProp("config.hardware")["config"]["hardware"]["device"]
-
-    scsi_controllers = devices.select { |dev| VIRTUAL_SCSI_CONTROLLERS.include?(dev.xsiType) }
+    scsi_controllers = getScsiControllers(hardware)
     scsi_controllers.each do |controller|
       scsi_controller_bus_numbers -= [controller["busNumber"].to_i]
     end
@@ -912,10 +912,10 @@ class MiqVimVm
   # Returns the [controllerKey, key] pair for the virtul device
   # associated with the given backing file.
   #
-  def getDeviceKeysByBacking(backingFile)
-    devs = getProp("config.hardware")["config"]["hardware"]["device"]
+  def getDeviceKeysByBacking(backingFile, hardware = nil)
+    hardware ||= getHardware()
 
-    devs.each do |dev|
+    hardware["device"].to_a.each do |dev|
       next if dev.xsiType != "VirtualDisk"
       next if dev["backing"]["fileName"] != backingFile
       return([dev["controllerKey"], dev["key"]])


### PR DESCRIPTION
When reconfiguring a VM there are a number of steps that need to operate on the VM's `config.hardware` hash.  Add a method to retrieve this once and allow it to be passed in to other methods to reduce the number of `retrieveProperties` calls made to the provider.

https://bugzilla.redhat.com/show_bug.cgi?id=1445874