### PR TITLE
Quiesce pglogical manager DB connection before allowing pg_restore to proceed

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -119,7 +119,7 @@ class PostgresAdmin
         LATERAL pglogical.drop_subscription(subs.sub_name)
     SQL
     runcmd("psql", opts, :command => <<-SQL)
-      DROP EXTENSTION pglogical CASCADE
+      DROP EXTENSION pglogical CASCADE
     SQL
   rescue AwesomeSpawn::CommandResultError
     $log.info("MIQ(#{name}.#{__method__}) Ignoring failure to remove pglogical before restore ...")


### PR DESCRIPTION
After dropping replication subscriptions and dropping the pglogical extension fro the PostgreSQL server, the connection own by pglogicl takes about 3 minutes to quiesce and exit.  The `before_restore` needs to wait for this connection to go away before returning. Otherwise, the report will bail due to the existing DB connection.

I discussed this with @jrafanie and we were debating whether we should do this or just allow it to return with a more descriptive message that would instruct the user to try the restore in a little while.

https://bugzilla.redhat.com/show_bug.cgi?id=1445803
https://bugzilla.redhat.com/show_bug.cgi?id=1444993