### PR TITLE
Simplify MiqUUID

### DIFF
--- a/lib/gems/pending/VolumeManager/MiqLdm.rb
+++ b/lib/gems/pending/VolumeManager/MiqLdm.rb
@@ -264,13 +264,13 @@ module LdmScanner
       vblk.dg_guid    = getChunk(buf)
 
     when VBT_DISKV2     # Disk v2
-      vblk.disk_guid1   = MiqUUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
-      vblk.disk_guid2   = MiqUUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
+      vblk.disk_guid1   = UUIDTools::UUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
+      vblk.disk_guid2   = UUIDTools::UUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
       ph.diskVb     = vblk if ph.disk_id == vblk.disk_guid1
 
     when VBT_DISKGROUPV2  # Disk Group v2
-      vblk.dg_guid    = MiqUUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
-      vblk.ds_guid    = MiqUUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
+      vblk.dg_guid    = UUIDTools::UUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
+      vblk.ds_guid    = UUIDTools::UUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
 
     when VBT_VOLUME     # Volume
       vblk.children   = []
@@ -287,7 +287,7 @@ module LdmScanner
       vblk.size     = getNum(buf)
       BinaryStruct.stepDecode(buf, "C4")
       vblk.partition_type = BinaryStruct.stepDecode(buf, "C")
-      vblk.volume_id    = MiqUUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
+      vblk.volume_id    = UUIDTools::UUID.parse_raw(BinaryStruct.stepDecode(buf, "a16")).to_s
 
       vblk.id1      = getChunk(buf) if (vblk.flags & 0x08) != 0x0
       vblk.id2      = getChunk(buf) if (vblk.flags & 0x20) != 0x0

--- a/lib/gems/pending/fs/ext3/superblock.rb
+++ b/lib/gems/pending/fs/ext3/superblock.rb
@@ -196,9 +196,9 @@ module Ext3
       @sb['last_mnt_path'].delete!("\000")
       @numGroups, @lastGroupBlocks = @sb['num_blocks'].divmod(@sb['blocks_in_group'])
       @numGroups += 1 if @lastGroupBlocks > 0
-      @fsId = MiqUUID.parse_raw(@sb['fs_id'])
+      @fsId = UUIDTools::UUID.parse_raw(@sb['fs_id'])
       @volName = @sb['vol_name']
-      @jrnlId = MiqUUID.parse_raw(@sb['jrnl_id'])
+      @jrnlId = UUIDTools::UUID.parse_raw(@sb['jrnl_id'])
     end
 
     # ////////////////////////////////////////////////////////////////////////////

--- a/lib/gems/pending/fs/ext4/superblock.rb
+++ b/lib/gems/pending/fs/ext4/superblock.rb
@@ -183,9 +183,9 @@ module Ext4
       @sb['last_mnt_path'].delete!("\000")
       @numGroups, @lastGroupBlocks = @sb['num_blocks'].divmod(@sb['blocks_in_group'])
       @numGroups += 1 if @lastGroupBlocks > 0
-      @fsId = MiqUUID.parse_raw(@sb['fs_id'])
+      @fsId = UUIDTools::UUID.parse_raw(@sb['fs_id'])
       @volName = @sb['vol_name']
-      @jrnlId = MiqUUID.parse_raw(@sb['jrnl_id'])
+      @jrnlId = UUIDTools::UUID.parse_raw(@sb['jrnl_id'])
     end
 
     # ////////////////////////////////////////////////////////////////////////////

--- a/lib/gems/pending/fs/ntfs/attrib_object_id.rb
+++ b/lib/gems/pending/fs/ntfs/attrib_object_id.rb
@@ -22,10 +22,10 @@ module NTFS
       raise "MIQ(NTFS::ObjectId.initialize) Nil buffer" if buf.nil?
       buf = buf.read(buf.length) if buf.kind_of?(DataRun)
       len = 16
-      @objectId       = MiqUUID.parse_raw(buf[len * 0, len])
-      @birthVolumeId  = MiqUUID.parse_raw(buf[len * 1, len]) if buf.length > 16
-      @birthObjectId  = MiqUUID.parse_raw(buf[len * 2, len]) if buf.length > 16
-      @domainId       = MiqUUID.parse_raw(buf[len * 3, len]) if buf.length > 16
+      @objectId       = UUIDTools::UUID.parse_raw(buf[len * 0, len])
+      @birthVolumeId  = UUIDTools::UUID.parse_raw(buf[len * 1, len]) if buf.length > 16
+      @birthObjectId  = UUIDTools::UUID.parse_raw(buf[len * 2, len]) if buf.length > 16
+      @domainId       = UUIDTools::UUID.parse_raw(buf[len * 3, len]) if buf.length > 16
     end
 
     def dump

--- a/lib/gems/pending/fs/xfs/superblock.rb
+++ b/lib/gems/pending/fs/xfs/superblock.rb
@@ -203,7 +203,7 @@ module XFS
       @allocation_group_blocks          = @sb['ag_blocks']
       @groups_count, @last_group_blocks = @sb['data_blocks'].divmod(@allocation_group_blocks)
       @groups_count += 1 if @last_group_blocks > 0
-      @filesystem_id                    = MiqUUID.parse_raw(@sb['uuid'])
+      @filesystem_id                    = UUIDTools::UUID.parse_raw(@sb['uuid'])
       @volume_name                      = @sb['fs_name']
       @ialloc_inos                      = (@sb['inodes_per_blk']..XFS_INODES_PER_CHUNK).max
       @ialloc_blks                      = @ialloc_inos >> @sb['inodes_per_blk_log']

--- a/lib/gems/pending/util/miq-uuid.rb
+++ b/lib/gems/pending/util/miq-uuid.rb
@@ -15,8 +15,4 @@ module MiqUUID
   def self.new_guid
     UUIDTools::UUID.timestamp_create.to_s
   end
-
-  def self.method_missing(m, *args)
-    UUIDTools::UUID.send(m, *args)
-  end
 end

--- a/lib/gems/pending/util/miq-uuid.rb
+++ b/lib/gems/pending/util/miq-uuid.rb
@@ -11,8 +11,4 @@ module MiqUUID
     g.delete!('^0-9a-f')
     g.sub!(/^([0-9a-f]{8})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{4})([0-9a-f]{12})$/, '\1-\2-\3-\4-\5')
   end
-
-  def self.new_guid
-    UUIDTools::UUID.timestamp_create.to_s
-  end
 end

--- a/spec/util/miq-uuid_spec.rb
+++ b/spec/util/miq-uuid_spec.rb
@@ -19,10 +19,4 @@ describe MiqUUID do
   MIQ_UUID_CASES.each_slice(3) do |title, value, expected|
     it(".clean_guid with #{title}") { expect(MiqUUID.clean_guid(value)).to eq(expected) }
   end
-
-  it ".new_guid" do
-    guid = MiqUUID.new_guid
-    expect(guid).to be_kind_of String
-    expect(guid).to match MiqUUID::REGEX_FORMAT
-  end
 end

--- a/spec/util/miq-uuid_spec.rb
+++ b/spec/util/miq-uuid_spec.rb
@@ -25,10 +25,4 @@ describe MiqUUID do
     expect(guid).to be_kind_of String
     expect(guid).to match MiqUUID::REGEX_FORMAT
   end
-
-  it ".parse_raw" do
-    guid = MiqUUID.parse_raw("\001#Eg\211\253\315\357\253\315\357\001#Eg\211")
-    expect(guid).to be_kind_of UUIDTools::UUID
-    expect(guid.to_s).to eq('01234567-89ab-cdef-abcd-ef0123456789')
-  end
 end


### PR DESCRIPTION
Depends on:
https://github.com/ManageIQ/manageiq/pull/14997
https://github.com/ManageIQ/manageiq-automation_engine/pull/12
https://github.com/ManageIQ/manageiq-providers-vmware/pull/56

We don't need `method_missing` to delegate to UUIDTools, update callers and remove `method_missing`.
`SecureRandom.uuid` generates a new guid, updated callers accordingly.