### PR TITLE
remove inherits from rubocop_local

### DIFF
--- a/.rubocop_local.yml
+++ b/.rubocop_local.yml
@@ -1,5 +1,3 @@
-inherit_from:
-- .rubocop_base.yml
 #
 # Overrides
 #


### PR DESCRIPTION
`rubocop_base.yml` should be downloaded from the ManageIQ/guides repo, not stored in this repo.  It should only be referenced from `.rubocop.yml`, `.rubocop_local.yml` should only have local overrides.