### PR TITLE
[FINE] Fix host targeted refresh

### DIFF
--- a/lib/gems/pending/ovirt_provider/inventory/ovirt_inventory.rb
+++ b/lib/gems/pending/ovirt_provider/inventory/ovirt_inventory.rb
@@ -86,8 +86,8 @@ class OvirtInventory
     @service.get_resource_by_ems_ref(uri_suffix, element_name)
   end
 
-  def get_resources_by_uri_path(uri_suffix, element_name = nil)
-    @service.get_resources_by_uri_path(uri_suffix, element_name)
+  def get_resources_by_uri_path(uri_suffix, element_name = nil, xpath = nil)
+    @service.get_resources_by_uri_path(uri_suffix, element_name, xpath)
   end
 
   def refresh
@@ -160,13 +160,14 @@ class OvirtInventory
 
   def collect_primary_targeted_jobs(jobs)
     results = collect_in_parallel(jobs) do |key, ems_ref|
+      xpath = key == :host ? '/host' : nil
       if ems_ref.kind_of?(Array)
-        ems_ref.flat_map { |item| get_resources_by_uri_path(item) rescue Array.new }
+        ems_ref.flat_map { |item| get_resources_by_uri_path(item, nil, xpath) rescue Array.new }
       elsif ems_ref.kind_of?(Hash)
         collection, element_name = ems_ref.first
         standard_collection(collection, element_name, true)
       else
-        get_resources_by_uri_path(ems_ref) rescue Array.new
+        get_resources_by_uri_path(ems_ref, nil, xpath) rescue Array.new
       end
     end
 

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-sftp",                "~>2.1.2"
   s.add_runtime_dependency "nokogiri",                "~>1.6.8"
   s.add_runtime_dependency "openscap",                "~>0.4.3"
-  s.add_runtime_dependency "ovirt",                   "~>0.15.1"
+  s.add_runtime_dependency "ovirt",                   "~>0.17.0"
   s.add_runtime_dependency "parallel",                "~>1.9" # For OvirtInventory
   s.add_runtime_dependency "pg",                      "~>0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~>0.1.0"


### PR DESCRIPTION
Partial backport of https://github.com/ManageIQ/manageiq-providers-ovirt/pull/31

In V3 the host resources retrieved by
/ovirt-engine/api/hosts/{host:id} contains the statistics element. The
statistics element contains a reference to the host element. The xpath
used to collect similar host entries considered the host sub-element
as a resource to collect, which lead to collecting the same host
multiple times. By specifying the exact top level host path, this will
be avoided.

https://bugzilla.redhat.com/show_bug.cgi?id=1448690