### PR TITLE
bump kubeclient ~> 2.4.0

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "httpclient",              "~>2.7.1"
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"
   s.add_runtime_dependency "iniparse"
-  s.add_runtime_dependency "kubeclient",              "=2.3.0"
+  s.add_runtime_dependency "kubeclient",              "~>2.4.0"
   s.add_runtime_dependency "linux_admin",             "~>0.20.1"
   s.add_runtime_dependency "linux_block_device",      "~>0.2.1"
   s.add_runtime_dependency "log4r",                   "=1.1.8"


### PR DESCRIPTION
Needed for ManageIQ/manageiq-providers-kubernetes#10 to control timeout.
https://bugzilla.redhat.com/show_bug.cgi?id=1440950

cc @moolitayer @simonz @agrare