### PR TITLE
Add attach/detach cloud volume errors

### DIFF
--- a/lib/gems/pending/util/miq-exception.rb
+++ b/lib/gems/pending/util/miq-exception.rb
@@ -133,6 +133,8 @@ module MiqException
   class MiqVolumeCreateError < Error; end
   class MiqVolumeUpdateError < Error; end
   class MiqVolumeDeleteError < Error; end
+  class MiqVolumeAttachError < Error; end
+  class MiqVolumeDetachError < Error; end
 
   class MiqCloudSubnetValidationError < Error; end
   class MiqCloudSubnetCreateError < Error; end


### PR DESCRIPTION
This adds two new error types that need to be thrown when cloud volume
attach/detach fails.

This patch is the first part of a followup to [this discussion](https://github.com/ManageIQ/manageiq-ui-classic/pull/1321#issuecomment-300578032).

/cc @bronaghs 