### PR TITLE
Remove obsolete code for Openstack Storage

### DIFF
--- a/lib/gems/pending/openstack/openstack_handle/handle.rb
+++ b/lib/gems/pending/openstack/openstack_handle/handle.rb
@@ -66,11 +66,6 @@ module OpenstackHandle
       }
       opts.merge!(extra_opts) if extra_opts
 
-      # Workaround for a bug in Fog
-      # https://github.com/fog/fog/issues/3112
-      # Ensure the that if the Storage service is not available, it will not
-      # throw an error trying to build an connection error message.
-      opts[:openstack_service_type] = ["object-store"] if service == "Storage"
       opts[:openstack_service_type] = ["nfv-orchestration"] if service == "NFV"
       opts[:openstack_service_type] = ["workflowv2"] if service == "Workflow"
 


### PR DESCRIPTION
Setting service_type manually is not needed since https://github.com/fog/fog/pull/3113
was merged and Fog updated in MiQ, which have happened already.