### PR TITLE
Remove rubywbem dependency

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,7 +5,6 @@ gemspec
 
 # Modified gems (forked on github)
 gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"
-gem "rubywbem",            :require => false, :git => "https://github.com/ManageIQ/rubywbem.git", :branch => "rubywbem_0_1_0"
 
 # This is needed because some of the smart analysis tests scripts, insde the 'lib/gems/pending/MiqVm/test' directory,
 # use the oVirt provider inventory classes.


### PR DESCRIPTION
Nothing in this repo references rubywbem, so I'm not really sure why it's here.  There is [the same reference in manageiq proper](https://github.com/ManageIQ/manageiq/blob/c4c4765421105573aad7665b5bee96d5ddc719f4/Gemfile#L12), so this is redundant.  I am (hopefully) removing rubywbem in ManageIQ/manageiq#15153.