### PR TITLE
Remove dependency on Log4r from VMwareWebService

### DIFF
--- a/lib/gems/pending/VMwareWebService/test/MiqVimBrokerClient.rb
+++ b/lib/gems/pending/VMwareWebService/test/MiqVimBrokerClient.rb
@@ -2,17 +2,9 @@ require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
+
 TARGET_VM = "NetAppDsTest7"
 
 begin

--- a/lib/gems/pending/VMwareWebService/test/MiqVimBrokerServer.rb
+++ b/lib/gems/pending/VMwareWebService/test/MiqVimBrokerServer.rb
@@ -1,5 +1,4 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVimBroker'
 
 SelectionSpec = {
@@ -78,19 +77,10 @@ SelectionSpec = {
   ]
 }
 
-#
-# Formatter to output log messages to the console.
-#
 $stderr.sync = true
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    t = Time.now
-    "[%s] %02d:%02d:%02d <%s>: %s\n" % [Log4r::LNAMES[event.level], t.hour, t.min, t.sec, Thread.current.object_id, event.data.kind_of?(String) ? event.data : event.data.inspect]
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 broker = nil
 

--- a/lib/gems/pending/VMwareWebService/test/MiqVimFolderTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/MiqVimFolderTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stderr.sync = true
 $stdout.sync = true

--- a/lib/gems/pending/VMwareWebService/test/MiqVimPerfTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/MiqVimPerfTest.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'enumerator'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # MiqVimClientBase.wiredump_file = "perf.txt"
 

--- a/lib/gems/pending/VMwareWebService/test/MiqVimVmTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/MiqVimVmTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # TARGET_VM = "rpo-test2"
 TARGET_VM = "NetappDsTest2"

--- a/lib/gems/pending/VMwareWebService/test/addDiskTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/addDiskTest.rb
@@ -1,23 +1,13 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVim'
-require 'log4r'
 
 unless ARGV.length == 1 && ARGV[0] =~ /(add|remove)/
   $stderr.puts "Usage: #{$0} add | remove"
   exit 1
 end
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 targetVm = raise "please define"
 targetVmPath = nil

--- a/lib/gems/pending/VMwareWebService/test/addHostToCluster.rb
+++ b/lib/gems/pending/VMwareWebService/test/addHostToCluster.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::OFF, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/lib/gems/pending/VMwareWebService/test/addNasDatastoreByName.rb
+++ b/lib/gems/pending/VMwareWebService/test/addNasDatastoreByName.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    "**** " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/lib/gems/pending/VMwareWebService/test/addStandaloneHost.rb
+++ b/lib/gems/pending/VMwareWebService/test/addStandaloneHost.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::OFF, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = ""

--- a/lib/gems/pending/VMwareWebService/test/alarmManagerTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/alarmManagerTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::INFO, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $DEBUG = true
 

--- a/lib/gems/pending/VMwareWebService/test/alarmTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/alarmTest.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 TARGET_VM = raise "please define"
 vim = MiqVim.new(SERVER, USERNAME, PASSWORD)

--- a/lib/gems/pending/VMwareWebService/test/annotation.rb
+++ b/lib/gems/pending/VMwareWebService/test/annotation.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/brokerObjCountTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/brokerObjCountTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::INFO, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/browserTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/browserTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/lib/gems/pending/VMwareWebService/test/cloneAsyncTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/cloneAsyncTest.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/lib/gems/pending/VMwareWebService/test/cloneCsmTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/cloneCsmTest.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/lib/gems/pending/VMwareWebService/test/cloneDvsTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/cloneDvsTest.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/lib/gems/pending/VMwareWebService/test/cloneTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/cloneTest.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/lib/gems/pending/VMwareWebService/test/cpuAffinity.rb
+++ b/lib/gems/pending/VMwareWebService/test/cpuAffinity.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/cpuMemTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/cpuMemTest.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 TARGET_VM = "rpo-test2"
 vmMor = nil

--- a/lib/gems/pending/VMwareWebService/test/createFolderTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/createFolderTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::OFF, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 SERVER   = ""
 USERNAME = ""

--- a/lib/gems/pending/VMwareWebService/test/createNfsDatastore.rb
+++ b/lib/gems/pending/VMwareWebService/test/createNfsDatastore.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    "**** " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/lib/gems/pending/VMwareWebService/test/customFieldsManagerTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/customFieldsManagerTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $DEBUG = true
 vim = MiqVim.new(SERVER, USERNAME, PASSWORD)

--- a/lib/gems/pending/VMwareWebService/test/customizationSpecManagerTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/customizationSpecManagerTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/diskPerf.rb
+++ b/lib/gems/pending/VMwareWebService/test/diskPerf.rb
@@ -1,29 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'enumerator'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  @@prog = File.basename(__FILE__, ".*")
-  def format(event)
-    "#{Log4r::LNAMES[event.level]} [#{datetime}] -- #{@@prog}: " +
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-  
-  private
-  
-  def datetime
-    time = Time.now.utc
-    time.strftime("%Y-%m-%dT%H:%M:%S.") << "%06d" % time.usec
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::INFO, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 $stderr.sync = true

--- a/lib/gems/pending/VMwareWebService/test/enterMaintenanceMode.rb
+++ b/lib/gems/pending/VMwareWebService/test/enterMaintenanceMode.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::OFF, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/lib/gems/pending/VMwareWebService/test/eventHistoryTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/eventHistoryTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/hostAdvancedOptionTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostAdvancedOptionTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::INFO, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $DEBUG = true
 

--- a/lib/gems/pending/VMwareWebService/test/hostConfigSpecTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostConfigSpecTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::DEBUG, :formatter=>ConsoleFormatter)
-$log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/hostDatastoreTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostDatastoreTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/lib/gems/pending/VMwareWebService/test/hostDvsTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostDvsTest.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/lib/gems/pending/VMwareWebService/test/hostFirewallTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostFirewallTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::DEBUG, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/hostNetworkTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostNetworkTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::DEBUG, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/hostServiceTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostServiceTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/hostSnmpSystemTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostSnmpSystemTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::DEBUG, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/hostStandByTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostStandByTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::OFF, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/lib/gems/pending/VMwareWebService/test/hostStorageSystem.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostStorageSystem.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    "**** " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 $miq_wiredump = true

--- a/lib/gems/pending/VMwareWebService/test/hostTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::OFF, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/hostVirtualNicManagerTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/hostVirtualNicManagerTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::DEBUG, :formatter=>ConsoleFormatter)
-$log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/linkedCloneFromTemplateTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/linkedCloneFromTemplateTest.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/lib/gems/pending/VMwareWebService/test/linkedCloneTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/linkedCloneTest.rb
@@ -1,20 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/VimTypes'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $miq_wiredump = false
 

--- a/lib/gems/pending/VMwareWebService/test/list_evm_snapshots.rb
+++ b/lib/gems/pending/VMwareWebService/test/list_evm_snapshots.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::OFF, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 if ARGV.length != 3
   $stderr.puts "Usage: #{$0} server username password"

--- a/lib/gems/pending/VMwareWebService/test/logTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/logTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $DEBUG = true
 $miq_wiredump = true

--- a/lib/gems/pending/VMwareWebService/test/migrateTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/migrateTest.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::INFO, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 TARGET_VM = "rpo-test2"
 vmMor = nil

--- a/lib/gems/pending/VMwareWebService/test/rebootHostTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/rebootHostTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::OFF, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/lib/gems/pending/VMwareWebService/test/remoteDisplayVnc.rb
+++ b/lib/gems/pending/VMwareWebService/test/remoteDisplayVnc.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/rm_evm_snapshots.rb
+++ b/lib/gems/pending/VMwareWebService/test/rm_evm_snapshots.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::OFF, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 if ARGV.length != 3
   $stderr.puts "Usage: #{$0} server username password"

--- a/lib/gems/pending/VMwareWebService/test/rtPerfTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/rtPerfTest.rb
@@ -1,29 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'enumerator'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  @@prog = File.basename(__FILE__, ".*")
-  def format(event)
-    "#{Log4r::LNAMES[event.level]} [#{datetime}] -- #{@@prog}: " +
-      (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-
-  private
-
-  def datetime
-    time = Time.now.utc
-    time.strftime("%Y-%m-%dT%H:%M:%S.") << "%06d" % time.usec
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 $stderr.sync = true

--- a/lib/gems/pending/VMwareWebService/test/selectionSpecBrokerClassTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/selectionSpecBrokerClassTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::OFF, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/selectionSpecBrokerInstanceTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/selectionSpecBrokerInstanceTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::OFF, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/selectionSpecVimClassTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/selectionSpecVimClassTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::OFF, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/selectionSpecVimTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/selectionSpecVimTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::OFF, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 

--- a/lib/gems/pending/VMwareWebService/test/shutdownHostTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/shutdownHostTest.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level=>Log4r::OFF, :formatter=>ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 TARGET_HOST   = raise "please define"

--- a/lib/gems/pending/VMwareWebService/test/snapshotTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/snapshotTest.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 

--- a/lib/gems/pending/VMwareWebService/test/templateTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/templateTest.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 TARGET_VM = "rpo-template-test"
 vmMor = nil

--- a/lib/gems/pending/VMwareWebService/test/thinProvisioned.rb
+++ b/lib/gems/pending/VMwareWebService/test/thinProvisioned.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 TARGET_VM = raise "please define"
 miqVm = nil

--- a/lib/gems/pending/VMwareWebService/test/vdlBrowserTest.rb
+++ b/lib/gems/pending/VMwareWebService/test/vdlBrowserTest.rb
@@ -1,21 +1,11 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'enumerator'
 
 require 'VMwareWebService/MiqVimBroker'
 require 'VixDiskLib/VixDiskLib'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stderr.sync = true
 $stdout.sync = true

--- a/lib/gems/pending/VMwareWebService/test/vimCoreUpdater.rb
+++ b/lib/gems/pending/VMwareWebService/test/vimCoreUpdater.rb
@@ -1,23 +1,12 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVimCoreUpdater'
 
 SERVER   = raise "please define SERVER"
 USERNAME = raise "please define USERNAME"
 PASSWORD = raise "please define PASSWORD"
-#
-# Formatter to output log messages to the console.
-#
-$stderr.sync = true
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    t = Time.now
-    "#{t.hour}:#{t.min}:#{t.sec}: " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 vimEm = MiqVimCoreUpdater.new(SERVER, USERNAME, PASSWORD)
 

--- a/lib/gems/pending/VMwareWebService/test/vimEventMonitory.rb
+++ b/lib/gems/pending/VMwareWebService/test/vimEventMonitory.rb
@@ -1,23 +1,12 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVimEventMonitor'
-require 'log4r'
 
 SERVER   = raise "please define SERVER"
 USERNAME = raise "please define USERNAME"
 PASSWORD = raise "please define PASSWORD"
-#
-# Formatter to output log messages to the console.
-#
-$stderr.sync = true
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    t = Time.now
-    "#{t.hour}:#{t.min}:#{t.sec}: " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 vimEm = MiqVimEventMonitor.new(SERVER, USERNAME, PASSWORD)
 

--- a/lib/gems/pending/VMwareWebService/test/vimInventory.rb
+++ b/lib/gems/pending/VMwareWebService/test/vimInventory.rb
@@ -1,21 +1,13 @@
 require 'manageiq-gems-pending'
 require 'VMwareWebService/MiqVimInventory'
-require 'log4r'
 
 SERVER   = raise "please define SERVER"
 USERNAME = raise "please define USERNAME"
 PASSWORD = raise "please define PASSWORD"
 
 $stderr.sync = true
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    t = Time.now
-    "#{t.hour}:#{t.min}:#{t.sec}: " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::DEBUG, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump       = true
 vim = MiqVimInventory.new(SERVER, USERNAME, PASSWORD)

--- a/lib/gems/pending/VMwareWebService/test/virtualApp.rb
+++ b/lib/gems/pending/VMwareWebService/test/virtualApp.rb
@@ -1,19 +1,9 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    "**** " + (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 # $miq_wiredump = true

--- a/lib/gems/pending/VMwareWebService/test/virtualDiskPerf.rb
+++ b/lib/gems/pending/VMwareWebService/test/virtualDiskPerf.rb
@@ -1,29 +1,10 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'enumerator'
 require 'VMwareWebService/MiqVim'
 require 'VMwareWebService/MiqVimBroker'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  @@prog = File.basename(__FILE__, ".*")
-  def format(event)
-    "#{Log4r::LNAMES[event.level]} [#{datetime}] -- #{@@prog}: " +
-      (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-
-  private
-
-  def datetime
-    time = Time.now.utc
-    time.strftime("%Y-%m-%dT%H:%M:%S.") << "%06d" % time.usec
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::ERROR, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 $stdout.sync = true
 $stderr.sync = true

--- a/lib/gems/pending/VMwareWebService/test/vmsafe.rb
+++ b/lib/gems/pending/VMwareWebService/test/vmsafe.rb
@@ -1,18 +1,8 @@
 require 'manageiq-gems-pending'
-require 'log4r'
 require 'VMwareWebService/MiqVim'
 
-#
-# Formatter to output log messages to the console.
-#
-class ConsoleFormatter < Log4r::Formatter
-  def format(event)
-    (event.data.kind_of?(String) ? event.data : event.data.inspect) + "\n"
-  end
-end
-$vim_log = Log4r::Logger.new 'toplog'
-Log4r::StderrOutputter.new('err_console', :level => Log4r::INFO, :formatter => ConsoleFormatter)
-$vim_log.add 'err_console'
+$vim_log = Logger.new(STDOUT)
+$vim_log.level = Logger::WARN
 
 # $miq_wiredump = true
 


### PR DESCRIPTION
Remove custom console formatter and `Log4r` dependencies and just use a standard `Logger.new(STDOUT)` for manual `VMwareWebService` tests 