### PR TITLE
Remove httpclient dependency from gems-pending

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -33,7 +33,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "excon",                   "~>0.40"
   s.add_runtime_dependency "fog-openstack",           "=0.1.20"
   s.add_runtime_dependency "highline",                "~> 1.6.21" # Needed for the appliance_console
-  s.add_runtime_dependency "httpclient",              "~>2.7.1"
   s.add_runtime_dependency "image-inspector-client",  "~>1.0.3"
   s.add_runtime_dependency "iniparse"
   s.add_runtime_dependency "kubeclient",              "~>2.4.0"


### PR DESCRIPTION
The httpclient gem was only used by VMwareWebService and handsoap so we
can remove it from the manageiq-gems-pending gemspec