### PR TITLE
Include tracking_label for vmdb-logger

### DIFF
--- a/lib/gems/pending/util/vmdb-logger.rb
+++ b/lib/gems/pending/util/vmdb-logger.rb
@@ -159,8 +159,8 @@ class VMDBLogger < Logger
 
     def prefix_task_id(msg)
       # Add task id to the message if a task is currently being worked on.
-      if $_miq_worker_current_msg && !$_miq_worker_current_msg.task_id.nil?
-        prefix = "Q-task_id([#{$_miq_worker_current_msg.task_id}])"
+      if (task_id = (Thread.current["tracking_label"] || $_miq_worker_current_msg.try(:task_id)))
+        prefix = "Q-task_id([#{task_id}])"
         msg = "#{prefix} #{msg}" unless msg.include?(prefix)
       end
 


### PR DESCRIPTION
In workers, we have a global variable `$_miq_worker_current_msg` that holds the current `MiqQueue` message being processed. This puts a common identifier in logs to help find related logging messages.

We are transitioning away from `task_id` for `MiqQueue` because the concept is not transferrable to other queuing technologies.

This change allows us to still have a global tracking label/identifier. It also lets us get away from a global that is very implementation specific.

Also, it allows us to get away from using `task_id` in some areas of code that don't need it, and still get the benefits of having a common identifier in the logs.

This is related to https://github.com/ManageIQ/manageiq/pull/15224


In the future, using an `mdc` for the log may be a better approach. This PR was just focused on removing the `MiqQueue` dependency and providing backwards compatibility.