### PR TITLE
Remove dependency on rufus-lru gem

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -49,7 +49,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "psych",                   "~>2.0.12"
   s.add_runtime_dependency "rake",                    ">=11.0"
   s.add_runtime_dependency "rubyzip",                 "~>1.2.0"
-  s.add_runtime_dependency "rufus-lru",               "~>1.0.3"
   s.add_runtime_dependency "sys-proctable",           "~>1.1.3"
   s.add_runtime_dependency "sys-uname",               "~>1.0.1"
   s.add_runtime_dependency "trollop",                 "~>2.0"


### PR DESCRIPTION
~~Could not find anything referencing `rufus-lru` nor `Rufus::Lru`~~

Moved dependency to https://github.com/ManageIQ/manageiq-smartstate/pull/7