### PR TITLE
Remove dependency on ovirt gem

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-sftp",                "~>2.1.2"
   s.add_runtime_dependency "nokogiri",                "~>1.7.1"
   s.add_runtime_dependency "openscap",                "~>0.4.3"
-  s.add_runtime_dependency "ovirt"                    # Version specified by manageiq-providers-ovirt.  TODO: remove direct dependencies on 'ovirt'.
   s.add_runtime_dependency "pg",                      "~>0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~>0.1.0"
   s.add_runtime_dependency "psych",                   "~>2.0.12"


### PR DESCRIPTION
Only callers seem to be in https://github.com/ManageIQ/manageiq-providers-ovirt and https://github.com/ManageIQ/manageiq-network_discovery which already declare their dependencies in their respective gemspec files.