### PR TITLE
Remove dependency on vmware_web_service gem

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -55,7 +55,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "uuidtools",               "~>2.1.3"
   s.add_runtime_dependency "winrm",                   "~>2.1"
   s.add_runtime_dependency "winrm-elevated",          "~>1.0.1"
-  s.add_runtime_dependency "vmware_web_service",      "~>0.1.1"
 
   s.add_development_dependency "rspec",        "~>3.5.0"
   s.add_development_dependency "test-unit"


### PR DESCRIPTION
It is a direct dependency in https://github.com/ManageIQ/manageiq/blob/master/Gemfile#L87, https://github.com/ManageIQ/manageiq/blob/master/Gemfile#L87 and https://github.com/ManageIQ/manageiq/blob/master/Gemfile#L87.

Waiting on https://github.com/ManageIQ/manageiq-providers-vmware/pull/63