### PR TITLE
Configure appliance as dedicated database with appliance_console_cli

### DIFF
--- a/lib/gems/pending/appliance_console/cli.rb
+++ b/lib/gems/pending/appliance_console/cli.rb
@@ -114,6 +114,7 @@ module ApplianceConsole
         opt :password, "Database Password",  :type => :string,  :short => "p"
         opt :dbname,   "Database Name",      :type => :string,  :short => "d", :default => "vmdb_production"
         opt :key,      "Create encryption key",  :type => :boolean, :short => "k"
+        opt :dedicated, "Dedicated database instance", :type => :bool, :short => 'D', :default => false
         opt :fetch_key, "SSH host with encryption key", :type => :string, :short => "K"
         opt :force_key, "Forcefully create encryption key", :type => :boolean, :short => "f"
         opt :sshlogin,  "SSH login",         :type => :string,                 :default => "root"
@@ -176,13 +177,15 @@ module ApplianceConsole
 
     def set_internal_db
       say "configuring internal database"
+      dedicated = if options[:dedicated] then true else false end
       config = ApplianceConsole::InternalDatabaseConfiguration.new({
         :database    => options[:dbname],
         :region      => options[:region],
         :username    => options[:username],
         :password    => options[:password],
         :interactive => false,
-        :disk        => disk_from_string(options[:dbdisk])
+        :disk        => disk_from_string(options[:dbdisk]),
+        :run_as_evm_server => dedicated
       }.delete_if { |_n, v| v.nil? })
 
       # create partition, pv, vg, lv, ext4, update fstab, mount disk

--- a/lib/gems/pending/appliance_console/cli.rb
+++ b/lib/gems/pending/appliance_console/cli.rb
@@ -177,15 +177,14 @@ module ApplianceConsole
 
     def set_internal_db
       say "configuring internal database"
-      dedicated = if options[:dedicated] then true else false end
       config = ApplianceConsole::InternalDatabaseConfiguration.new({
-        :database    => options[:dbname],
-        :region      => options[:region],
-        :username    => options[:username],
-        :password    => options[:password],
-        :interactive => false,
-        :disk        => disk_from_string(options[:dbdisk]),
-        :run_as_evm_server => dedicated
+        :database          => options[:dbname],
+        :region            => options[:region],
+        :username          => options[:username],
+        :password          => options[:password],
+        :interactive       => false,
+        :disk              => disk_from_string(options[:dbdisk]),
+        :run_as_evm_server => !options[:dedicated]
       }.delete_if { |_n, v| v.nil? })
 
       # create partition, pv, vg, lv, ext4, update fstab, mount disk


### PR DESCRIPTION
Add a new option to allow configuring appliance as dedicated database