### PR TITLE
Allow configuring appliance as dedicated database with appliance_console_cli

### DIFF
--- a/lib/gems/pending/appliance_console/cli.rb
+++ b/lib/gems/pending/appliance_console/cli.rb
@@ -113,6 +113,7 @@ module ApplianceConsole
         opt :username, "Database Username",  :type => :string,  :short => 'U', :default => "root"
         opt :password, "Database Password",  :type => :string,  :short => "p"
         opt :dbname,   "Database Name",      :type => :string,  :short => "d", :default => "vmdb_production"
+        opt :standalone, "Run this server as a standalone database server", :type => :bool, :short => 'S'
         opt :key,      "Create encryption key",  :type => :boolean, :short => "k"
         opt :fetch_key, "SSH host with encryption key", :type => :string, :short => "K"
         opt :force_key, "Forcefully create encryption key", :type => :boolean, :short => "f"
@@ -177,12 +178,13 @@ module ApplianceConsole
     def set_internal_db
       say "configuring internal database"
       config = ApplianceConsole::InternalDatabaseConfiguration.new({
-        :database    => options[:dbname],
-        :region      => options[:region],
-        :username    => options[:username],
-        :password    => options[:password],
-        :interactive => false,
-        :disk        => disk_from_string(options[:dbdisk])
+        :database          => options[:dbname],
+        :region            => options[:region],
+        :username          => options[:username],
+        :password          => options[:password],
+        :interactive       => false,
+        :disk              => disk_from_string(options[:dbdisk]),
+        :run_as_evm_server => !options[:standalone]
       }.delete_if { |_n, v| v.nil? })
 
       # create partition, pv, vg, lv, ext4, update fstab, mount disk

--- a/spec/appliance_console/cli_spec.rb
+++ b/spec/appliance_console/cli_spec.rb
@@ -37,11 +37,12 @@ describe ApplianceConsole::Cli do
     expect(subject).to receive(:disk_from_string).with('x').and_return('/dev/x')
     expect(subject).to receive(:say)
     expect(ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
-      .with(:region      => 1,
-            :database    => 'vmdb_production',
-            :username    => 'root',
-            :interactive => false,
-            :disk        => '/dev/x')
+      .with(:region            => 1,
+            :database          => 'vmdb_production',
+            :username          => 'root',
+            :interactive       => false,
+            :disk              => '/dev/x',
+            :run_as_evm_server => true)
       .and_return(double(:activate => true, :post_activation => true))
     expect(subject.key_configuration).not_to receive(:activate)
     subject.run
@@ -53,14 +54,32 @@ describe ApplianceConsole::Cli do
     expect(subject).to receive(:disk_from_string).and_return('x')
     expect(subject).to receive(:say)
     expect(ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
-      .with(:region      => 1,
-            :database    => 'vmdb_production',
-            :username    => 'user',
-            :password    => 'pass',
-            :interactive => false,
-            :disk        => 'x')
+      .with(:region            => 1,
+            :database          => 'vmdb_production',
+            :username          => 'user',
+            :password          => 'pass',
+            :interactive       => false,
+            :disk              => 'x',
+            :run_as_evm_server => true)
       .and_return(double(:activate => true, :post_activation => true))
 
+    subject.run
+  end
+
+  it "should pass standalone flag when configuring database in standalone mode" do
+    subject.parse(%w(--internal --username user --password pass -r 1 --dbdisk x --standalone))
+    expect_v2_key
+    expect(subject).to receive(:disk_from_string).and_return('x')
+    expect(subject).to receive(:say)
+    expect(ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
+      .with(:region            => 1,
+            :database          => 'vmdb_production',
+            :username          => 'user',
+            :password          => 'pass',
+            :interactive       => false,
+            :disk              => 'x',
+            :run_as_evm_server => false)
+      .and_return(double(:activate => true, :post_activation => true))
     subject.run
   end
 
@@ -71,12 +90,13 @@ describe ApplianceConsole::Cli do
     expect(subject).to receive(:say).twice
     config_double = double(:activate => false)
     expect(ApplianceConsole::InternalDatabaseConfiguration).to receive(:new)
-      .with(:region      => 1,
-            :database    => 'vmdb_production',
-            :username    => 'user',
-            :password    => 'pass',
-            :interactive => false,
-            :disk        => 'x')
+      .with(:region            => 1,
+            :database          => 'vmdb_production',
+            :username          => 'user',
+            :password          => 'pass',
+            :interactive       => false,
+            :disk              => 'x',
+            :run_as_evm_server => true)
       .and_return(config_double)
     expect(config_double).not_to receive(:post_activation)
 


### PR DESCRIPTION
Add option to appliance_console_cli that allows configuring appliance as dedicated database