### PR TITLE
Add 600 second cache timeout to pickup directory changes.

### DIFF
--- a/lib/gems/pending/appliance_console/external_httpd_configuration.rb
+++ b/lib/gems/pending/appliance_console/external_httpd_configuration.rb
@@ -106,6 +106,9 @@ module ApplianceConsole
           pattern = "[domain/#{Regexp.escape(domain)}].*(\n)"
           config[/#{pattern}/, 1] = "\nldap_user_extra_attrs = #{ldap_user_extra_attrs}\n"
         end
+
+        pattern = "[domain/#{Regexp.escape(domain)}].*(\n)"
+        config[/#{pattern}/, 1] = "\nentry_cache_timeout = 600\n"
       end
 
       def configure_sssd_service(config)


### PR DESCRIPTION
This PR creates a 10 minute cache timeout which will result in changes made on the
remote directory replacing cached values in 10 minutes.

The IdM team replied with the following regarding the impact to MiQ of reducing entry_cache_timeout, from the default of of 90 minutes, to a few seconds, or few a minutes:

> For Web applications, the performance impact should be really low
> since the user attributes and group membership gets consulted only
> during logon, not afterwards (unlike typical operations on the OS).

Also, this change is consistent with what we document for external auth via manually configured
[SSSD/LDAP](http://manageiq.org/docs/reference/latest/auth/ldap)

Addresses:
https://bugzilla.redhat.com/show_bug.cgi?id=1447064



