### PR TITLE
Allow IPv4 DNS for IPv6 network

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -248,7 +248,7 @@ Static Network Configuration
           new_ip = ask_for_ipv6('IP Address', eth0.address6)
           new_prefix = ask_for_integer('IPv6 prefix length', 1..127, eth0.prefix6 || 64)
           new_gw = ask_for_ipv6('Default gateway', eth0.gateway6)
-          new_dns1 = ask_for_ipv6('Primary DNS', dns1)
+          new_dns1 = ask_for_ip('Primary DNS', dns1)
           new_dns2 = ask_for_ipv6_or_none("Secondary DNS (Enter 'none' for no value)")
 
           new_search_order = ask_for_many('domain', 'Domain search order', order)


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1448878

People may want to have static IPv6 and static IPv4 and use only IPv4 DNS.