### PR TITLE
Add Volume Backup-related exceptions

### DIFF
--- a/lib/gems/pending/util/miq-exception.rb
+++ b/lib/gems/pending/util/miq-exception.rb
@@ -129,6 +129,9 @@ module MiqException
   class MiqVolumeSnapshotUpdateError < Error; end
   class MiqVolumeSnapshotDeleteError < Error; end
 
+  class MiqVolumeBackupCreateError < Error; end
+  class MiqVolumeBackupRestoreError < Error; end
+
   class MiqSecurityGroupCreateError < Error; end
   class MiqSecurityGroupUpdateError < Error; end
   class MiqSecurityGroupDeleteError < Error; end


### PR DESCRIPTION
Errors from the provider API during volume creation and backup are being masked in MIQ because of missing exception classes. This PR adds the missing exception classes.

Intended to fix the problem evidenced in https://bugzilla.redhat.com/show_bug.cgi?id=1448827