### PR TITLE
Remove `util/vmdb-logger` from appliance_console

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -20,7 +20,6 @@ require 'highline/system_extensions'
 require 'rubygems'
 require 'bcrypt'
 require 'linux_admin'
-require 'util/vmdb-logger'
 require 'util/postgres_admin'
 require 'awesome_spawn'
 include HighLine::SystemExtensions


### PR DESCRIPTION
This is never used by the appliance console, as it ends up just using the default ruby logger for it's `default_logger`:

```ruby
def self.default_logger
  @default_logger ||= begin
    require 'logger'
    l = Logger.new(LOGFILE)
    l.level = Logger::INFO
    l
  end
end
```

`default_logger` is also a attr_writer on the class, so if `util/vmdb-logger` is wanted for the logger, a user can simply require that when loading the bin, and then assign the logger themselves onto the class variable.


QA
--
Confirm that the appliance console still functions just fine with this removed.