### PR TITLE
Removes psych as a dependency

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "nokogiri",                "~>1.7.2"
   s.add_runtime_dependency "pg",                      "~>0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~>0.1.0"
-  s.add_runtime_dependency "psych",                   "~>2.0.12"
   s.add_runtime_dependency "rake",                    ">=11.0"
   s.add_runtime_dependency "sys-proctable",           "~>1.1.3"
   s.add_runtime_dependency "sys-uname",               "~>1.0.1"


### PR DESCRIPTION
The psych dependency was added back when some monkey patches still existed in our codebase, were merged in my Aaron Patterson, and the one from ruby core was not updated to the latest version:

https://github.com/ManageIQ/manageiq/commit/907a679

Now that we support ruby 2.3+, the psych is on version 2.1+, so this dependency is no longer needed:

```console
$ irb
irb(main):001:0> Psych
NameError: uninitialized constant Psych
from (irb):1 from /Users/nicklamuro/.rubies/ruby-2.3.3/bin/irb:11:in `<main>'
irb(main):002:0> require 'psych'
=> true
irb(main):003:0> Psych.methods
=> [:dump, :load, :quick_emit, :parse, :load_file, ... ]
irb(main):004:0> Psych.method(:dump).source_location
=> ["/Users/nicklamuro/.rubies/ruby-2.3.3/lib/ruby/2.3.0/psych.rb", 411]
irb(main):005:0>  Psych::VERSION
=> "2.1.0"
irb(main):006:0>
```