### PR TITLE
[WIP] Fix bug: existed v2_key deleted even if fetch/create new v2_key fails

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,5 +4,6 @@ language: ruby
 rvm:
   - 2.2.6
   - 2.3.3
+  - 2.4.1
 before_install: gem install bundler -v 1.12.5
 after_script: bundle exec codeclimate-test-reporter

--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -20,7 +20,6 @@ require 'highline/system_extensions'
 require 'rubygems'
 require 'bcrypt'
 require 'linux_admin'
-require 'util/vmdb-logger'
 require 'util/postgres_admin'
 require 'awesome_spawn'
 include HighLine::SystemExtensions

--- a/lib/gems/pending/appliance_console/key_configuration.rb
+++ b/lib/gems/pending/appliance_console/key_configuration.rb
@@ -46,7 +46,7 @@ module ApplianceConsole
     end
 
     def activate
-      if key_exist? and force
+      if key_exist? && force
         backup_key
       end
 
@@ -74,11 +74,11 @@ module ApplianceConsole
     end
 
     def restore_key_if_any
-      FileUtils.mv(KEY_FILE_BACKUP, KEY_FILE) if File.exists?(KEY_FILE_BACKUP)
+      FileUtils.mv(KEY_FILE_BACKUP, KEY_FILE) if File.exist?(KEY_FILE_BACKUP)
     end
 
     def remove_backup_key_if_any
-      FileUtils.rm(KEY_FILE_BACKUP) if File.exists?(KEY_FILE_BACKUP)
+      FileUtils.rm(KEY_FILE_BACKUP) if File.exist?(KEY_FILE_BACKUP)
     end
 
     def key_exist?

--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -3,7 +3,6 @@
 require 'sys-uname'
 require 'sys/proctable'
 require 'util/runcmd'
-require 'util/win32/miq-wmi'
 require 'util/miq-system'
 
 class MiqProcess
@@ -12,6 +11,7 @@ class MiqProcess
 
     case Sys::Platform::IMPL
     when :mswin, :mingw
+      require 'util/win32/miq-wmi'
       WMIHelper.connectServer.run_query("select Handle,Name from Win32_Process where Name = '#{process_name}.exe'") { |p| pids << p.Handle.to_i }
     when :linux, :macosx
       pids = `ps -e | grep #{process_name} | grep -v grep `.split("\n").collect(&:to_i)
@@ -88,6 +88,7 @@ class MiqProcess
 
     case Sys::Platform::IMPL
     when :mswin, :mingw
+      require 'util/win32/miq-wmi'
       # WorkingSetSize: The amount of memory in bytes that a process needs to execute efficiently, for an operating system that uses
       #                 page-based memory management. If an insufficient amount of memory is available (< working set size), thrashing will occur.
       # KernelModeTime: Time in kernel mode, in 100 nanoseconds
@@ -161,6 +162,7 @@ class MiqProcess
   end
 
   def self.process_list_wmi(wmi = nil, pid = nil)
+    require 'util/win32/miq-wmi'
     pl = {}
     wmi = WMIHelper.connectServer if wmi.nil?
     os_data = wmi.get_instance('select TotalVisibleMemorySize from Win32_OperatingSystem')

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -38,7 +38,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "nokogiri",                "~>1.7.2"
   s.add_runtime_dependency "pg",                      "~>0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~>0.1.0"
-  s.add_runtime_dependency "psych",                   "~>2.0.12"
   s.add_runtime_dependency "rake",                    ">=11.0"
   s.add_runtime_dependency "sys-proctable",           "~>1.1.3"
   s.add_runtime_dependency "sys-uname",               "~>1.0.1"

--- a/spec/appliance_console/key_configuration_spec.rb
+++ b/spec/appliance_console/key_configuration_spec.rb
@@ -63,6 +63,7 @@ describe ApplianceConsole::KeyConfiguration do
         it "fetches key" do
           v2_exists(false) # before download, check if backup
           v2_exists(false) # before download, in call remove_key
+          v2_backup_exists(false)
           v2_exists(true)  # after downloaded
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password)
           expect(subject.activate).to be_truthy
@@ -72,6 +73,7 @@ describe ApplianceConsole::KeyConfiguration do
           subject.action = :create
           v2_exists(false) # checked if backup
           v2_exists(false) # in call remove_key
+          v2_backup_exists(false)
           expect(MiqPassword).to receive(:generate_symmetric).and_return(154)
           expect(subject.activate).to be_truthy
         end
@@ -82,6 +84,7 @@ describe ApplianceConsole::KeyConfiguration do
           subject.force = true
           v2_exists(true) # before downloaded, check if backup
           v2_exists(true) # before downloaded, in call remove_key
+          v2_backup_exists(true)
           expect(FileUtils).to receive(:rm).with(/v2_key/).and_return(["v2_key"])
           v2_exists(true) # after downloaded
           expect(FileUtils).to receive(:rm).with(/bak/).and_return(["vk.bak"])
@@ -96,6 +99,7 @@ describe ApplianceConsole::KeyConfiguration do
           subject.force = false
           v2_exists(true) # check if backup
           v2_exists(true) # in call remove_key
+          v2_backup_exists(false)
           expect(FileUtils).not_to receive(:rm)
           expect(Net::SCP).not_to receive(:start)
           expect(subject.activate).to be_falsey
@@ -108,5 +112,9 @@ describe ApplianceConsole::KeyConfiguration do
 
   def v2_exists(value = true)
     expect(File).to receive(:exist?).with(/v2/).and_return(value)
+  end
+
+  def v2_backup_exists(value = true)
+    expect(File).to receive(:exist?).with(/bak/).and_return(value)
   end
 end

--- a/spec/appliance_console/key_configuration_spec.rb
+++ b/spec/appliance_console/key_configuration_spec.rb
@@ -63,7 +63,6 @@ describe ApplianceConsole::KeyConfiguration do
         it "fetches key" do
           v2_exists(false) # before download, check if backup
           v2_exists(false) # before download, in call remove_key
-          v2_backup_exists(false)
           v2_exists(true)  # after downloaded
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password)
           expect(subject.activate).to be_truthy
@@ -73,7 +72,6 @@ describe ApplianceConsole::KeyConfiguration do
           subject.action = :create
           v2_exists(false) # checked if backup
           v2_exists(false) # in call remove_key
-          v2_backup_exists(false)
           expect(MiqPassword).to receive(:generate_symmetric).and_return(154)
           expect(subject.activate).to be_truthy
         end
@@ -84,7 +82,6 @@ describe ApplianceConsole::KeyConfiguration do
           subject.force = true
           v2_exists(true) # before downloaded, check if backup
           v2_exists(true) # before downloaded, in call remove_key
-          v2_backup_exists(true)
           expect(FileUtils).to receive(:rm).with(/v2_key/).and_return(["v2_key"])
           v2_exists(true) # after downloaded
           expect(FileUtils).to receive(:rm).with(/bak/).and_return(["vk.bak"])
@@ -99,7 +96,6 @@ describe ApplianceConsole::KeyConfiguration do
           subject.force = false
           v2_exists(true) # check if backup
           v2_exists(true) # in call remove_key
-          v2_backup_exists(false)
           expect(FileUtils).not_to receive(:rm)
           expect(Net::SCP).not_to receive(:start)
           expect(subject.activate).to be_falsey
@@ -112,9 +108,5 @@ describe ApplianceConsole::KeyConfiguration do
 
   def v2_exists(value = true)
     expect(File).to receive(:exist?).with(/v2/).and_return(value)
-  end
-
-  def v2_backup_exists(value = true)
-    expect(File).to receive(:exist?).with(/bak/).and_return(value)
   end
 end

--- a/spec/appliance_console/key_configuration_spec.rb
+++ b/spec/appliance_console/key_configuration_spec.rb
@@ -109,8 +109,4 @@ describe ApplianceConsole::KeyConfiguration do
   def v2_exists(value = true)
     expect(File).to receive(:exist?).with(/v2/).and_return(value)
   end
-
-  def v2_backup_exists(value = true)
-    expect(File).to receive(:exist?).with(/bak/).and_return(value)
-  end
 end


### PR DESCRIPTION
**ISSUE**: When user decide to fetch a new v2_key from appliance console, and choose overwrite existing encryption key. If the user fails to get a new v2_key, the old one is still lost, and no way to recover.

BZ: [https://bugzilla.redhat.com/show_bug.cgi?id=1430701](https://bugzilla.redhat.com/show_bug.cgi?id=1430701
)

\cc @yrudman @gtanzillo 