### PR TITLE
Fix bug: existed v2_key deleted even if fetch/create new v2_key fails

### DIFF
--- a/lib/gems/pending/appliance_console/key_configuration.rb
+++ b/lib/gems/pending/appliance_console/key_configuration.rb
@@ -47,8 +47,7 @@ module ApplianceConsole
 
     def activate
       if !key_exist? || force
-        success_get_new = get_new_key
-        if success_get_new
+        if get_new_key
           save_new_key
         else
           remove_new_key_if_any
@@ -68,7 +67,7 @@ module ApplianceConsole
 
     def save_new_key
       FileUtils.mv(NEW_KEY_FILE, KEY_FILE, :force => true)
-    rescue StandardError => e
+    rescue => e
       say("Failed to overwrite original key, original key kept. #{e.message}")
       return false
     end

--- a/spec/appliance_console/key_configuration_spec.rb
+++ b/spec/appliance_console/key_configuration_spec.rb
@@ -64,7 +64,7 @@ describe ApplianceConsole::KeyConfiguration do
           v2_exists(false) # before download
           v2_exists(true)  # after downloaded
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password)
-          expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/).and_return(true)
+          expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
           expect(subject.activate).to be_truthy
         end
 
@@ -72,7 +72,7 @@ describe ApplianceConsole::KeyConfiguration do
           subject.action = :create
           v2_exists(false)
           expect(MiqPassword).to receive(:generate_symmetric).and_return(154)
-          expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/).and_return(true)
+          expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
           expect(subject.activate).to be_truthy
         end
       end
@@ -85,7 +85,7 @@ describe ApplianceConsole::KeyConfiguration do
           scp = double('scp')
           expect(scp).to receive(:download!).with(subject.key_path, /v2_key/).and_return(:result)
           expect(Net::SCP).to receive(:start).with(host, "root", :password => password).and_yield(scp).and_return(true)
-          expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/).and_return(true)
+          expect(FileUtils).to receive(:mv).with(/v2_key\.tmp/, /v2_key$/, :force=>true).and_return(true)
           expect(subject.activate).to be_truthy
         end
 
@@ -105,7 +105,7 @@ describe ApplianceConsole::KeyConfiguration do
           mock_key.print(key_content)
           mock_key.close
           stub_const("ApplianceConsole::KEY_FILE", mock_key.path)
-          stub_const("ApplianceConsole::KEY_FILE_TEMP", mock_key.path + ".tmp")
+          stub_const("ApplianceConsole::NEW_KEY_FILE", mock_key.path + ".tmp")
           expect(subject).to receive(:fetch_key).and_return(false)
           expect(subject.activate).to be_falsey
           expect(FileUtils).not_to receive(:mv)


### PR DESCRIPTION
**ISSUE**: When user decide to fetch a new v2_key from appliance console, and choose overwrite existing encryption key. If the user fails to get a new v2_key, the old one is still lost, and no way to recover.

BZ: [https://bugzilla.redhat.com/show_bug.cgi?id=1430701](https://bugzilla.redhat.com/show_bug.cgi?id=1430701
                                                          )

\cc @yrudman @gtanzillo

@miq-bot add-label wip, bug