### PR TITLE
Consider database.yml not configured if we don't have a v2_key

### DIFF
--- a/lib/gems/pending/appliance_console/database_configuration.rb
+++ b/lib/gems/pending/appliance_console/database_configuration.rb
@@ -7,6 +7,7 @@ require 'fileutils'
 require 'appliance_console/errors'
 require 'appliance_console/utilities'
 require 'appliance_console/logging'
+require 'appliance_console/key_configuration'
 
 RAILS_ROOT ||= Pathname.new(__dir__).join("../../..")
 
@@ -196,7 +197,7 @@ FRIENDLY
     end
 
     def self.database_yml_configured?
-      File.exist?(DB_YML)
+      File.exist?(DB_YML) && File.exist?(KEY_FILE)
     end
 
     def self.database_host

--- a/spec/appliance_console/database_configuration_spec.rb
+++ b/spec/appliance_console/database_configuration_spec.rb
@@ -396,7 +396,8 @@ describe ApplianceConsole::DatabaseConfiguration do
   end
 
   context "with test database yml file" do
-    let(:db_yml) { Tempfile.new("appliance_console_database.yml") }
+    let(:db_yml)   { Tempfile.new("appliance_console_database.yml") }
+    let(:key_file) { Tempfile.new("encryption_key") }
 
     around(:each) do |example|
       db_yml.write(<<-DBYML)
@@ -413,15 +414,19 @@ env2:
   username: user2
 DBYML
       db_yml.close
+      key_file.write("encryption_key")
+      key_file.close
       begin
         example.run
       ensure
         db_yml.unlink
+        key_file.unlink
       end
     end
 
     before do
       stub_const("#{described_class}::DB_YML", db_yml.path)
+      stub_const("ApplianceConsole::KEY_FILE", key_file.path)
     end
 
     describe ".database_host" do


### PR DESCRIPTION
This becomes an issue in the unlikely scenario where a v2_key is not present, but there are v2 encrypted strings in database.yml

This allows the user to create a new v2_key using the console which would previously fail to even start in this situation.

Follow up to #211

https://bugzilla.redhat.com/show_bug.cgi?id=1430701