### PR TITLE
make prefixing the task id a method

### DIFF
--- a/lib/gems/pending/util/vmdb-logger.rb
+++ b/lib/gems/pending/util/vmdb-logger.rb
@@ -150,15 +150,21 @@ class VMDBLogger < Logger
     FORMAT = "[----] %s, [%s#%d:%x] %5s -- %s: %s\n"
 
     def call(severity, time, progname, msg)
-      msg = msg2str(msg)
+      msg = prefix_task_id(msg2str(msg))
 
+      FORMAT % [severity[0..0], format_datetime(time), $$, Thread.current.object_id, severity, progname, msg]
+    end
+
+    private
+
+    def prefix_task_id(msg)
       # Add task id to the message if a task is currently being worked on.
       if $_miq_worker_current_msg && !$_miq_worker_current_msg.task_id.nil?
         prefix = "Q-task_id([#{$_miq_worker_current_msg.task_id}])"
         msg = "#{prefix} #{msg}" unless msg.include?(prefix)
       end
 
-      FORMAT % [severity[0..0], format_datetime(time), $$, Thread.current.object_id, severity, progname, msg]
+      msg
     end
   end
 end

--- a/lib/gems/pending/util/vmdb-logger.rb
+++ b/lib/gems/pending/util/vmdb-logger.rb
@@ -152,7 +152,7 @@ class VMDBLogger < Logger
     def call(severity, time, progname, msg)
       msg = prefix_task_id(msg2str(msg))
 
-      FORMAT % [severity[0..0], format_datetime(time), $$, Thread.current.object_id, severity, progname, msg]
+      FORMAT % [severity[0..0], format_datetime(time), $PROCESS_ID, Thread.current.object_id, severity, progname, msg]
     end
 
     private


### PR DESCRIPTION
This allows the same logic to be reused by other formatters that inherit from this formatter