### PR TITLE
Enter password once when connecting to external (existed) DB

### DIFF
--- a/lib/gems/pending/appliance_console/database_configuration.rb
+++ b/lib/gems/pending/appliance_console/database_configuration.rb
@@ -114,7 +114,7 @@ module ApplianceConsole
       raise MiqSignalError if warn && !agree(CREATE_REGION_AGREE)
     end
 
-    def ask_for_database_credentials
+    def ask_for_database_credentials(password_twice = true)
       self.host     = ask_for_ip_or_hostname("database hostname or IP address", host) if host.blank? || !local?
       self.port     = ask_for_integer("port number", nil, port) unless local?
       self.database = just_ask("name of the database on #{host}", database) unless local?
@@ -124,20 +124,25 @@ module ApplianceConsole
         password1 = ask_for_password("database password on #{host}", password)
         # if they took the default, just bail
         break if (password1 == password)
-        
+
         if password1.strip.length == 0
           say("\nPassword can not be empty, please try again")
           next
         end
-        password2 = ask_for_password("database password again")
-        if password1 == password2
+        if password_twice
+          password2 = ask_for_password("database password again")
+          if password1 == password2
+            self.password = password1
+            break
+          elsif count > 0 # only reprompt password once
+            raise "passwords did not match"
+          else
+            count += 1
+            say("\nThe passwords did not match, please try again")
+          end
+        else
           self.password = password1
           break
-        elsif count > 0 # only reprompt password once
-          raise RuntimeError, "passwords did not match"
-        else
-          count += 1
-          say("\nThe passwords did not match, please try again")
         end
       end
     end

--- a/lib/gems/pending/appliance_console/external_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/external_database_configuration.rb
@@ -22,7 +22,7 @@ module ApplianceConsole
       create_new_region_questions if action == :create
       clear_screen
       say("Database Configuration\n")
-      ask_for_database_credentials
+      ask_for_database_credentials(false)
     end
 
     def post_activation

--- a/spec/appliance_console/database_configuration_spec.rb
+++ b/spec/appliance_console/database_configuration_spec.rb
@@ -220,6 +220,12 @@ describe ApplianceConsole::DatabaseConfiguration do
       expect(subject).to receive(:loop).and_yield
       subject.ask_for_database_credentials
     end
+
+    it "ask for password only once when password_twice is false" do
+      expect(subject).to receive(:just_ask).with(/password/i, anything).and_return("pass1")
+      subject.ask_for_database_credentials(false)
+      expect(subject.password).to eq("pass1")
+    end
   end
 
   context "#create_or_join_region" do
@@ -408,7 +414,6 @@ env1:
   database: database1
   username: user1
   host: host1.example.com
-
 env2:
   database: database2
   username: user2


### PR DESCRIPTION
**ISSUE**: When configure database in appliance console, password needs to be enter twice, which is unnecessary.

**BZ**: https://bugzilla.redhat.com/show_bug.cgi?id=1462032

\cc @gtanzillo @yrudman 

@miq-bot add-label bug,wip