### PR TITLE
can use arrow to navigate input in appliance console

### DIFF
--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -203,6 +203,7 @@ module ApplianceConsole
 
     def just_ask(prompt, default = nil, validate = nil, error_text = nil, klass = nil)
       ask("Enter the #{prompt}: ", klass) do |q|
+        q.readline = true
         q.default = default.to_s if default
         q.validate = validate if validate
         q.responses[:not_valid] = error_text ? "Please provide #{error_text}" : "Please provide in the specified format"

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -8,14 +8,14 @@ require 'highline/import'
 require "linux_admin"
 
 describe ApplianceConsole::Prompts do
-  let(:input) {
+  let(:input) do
     temp_stdin = Tempfile.new("temp_stdin")
     File.open(temp_stdin.path, 'w+')
-  }
-  let(:readline_output){
+  end
+  let(:readline_output) do
     temp_stdout = Tempfile.new("temp_stdout")
     File.open(temp_stdout.path, 'w+')
-  }
+  end
   let(:output) { StringIO.new }
   let(:prompt) { "\n?  " }
 

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -8,16 +8,20 @@ require 'highline/import'
 require "linux_admin"
 
 describe ApplianceConsole::Prompts do
-  let(:temp_stdin) { Tempfile.new "temp_stdin" }
-  let(:temp_stdout) { Tempfile.new "temp_stdout" }
-  let(:input) { File.open(temp_stdin.path, 'w+') }
-  let(:output_with_input) { File.open(temp_stdout.path, 'w+') }
+  let(:input) {
+    temp_stdin = Tempfile.new("temp_stdin")
+    File.open(temp_stdin.path, 'w+')
+  }
+  let(:readline_output){
+    temp_stdout = Tempfile.new("temp_stdout")
+    File.open(temp_stdout.path, 'w+')
+  }
   let(:output) { StringIO.new }
-  let(:prompt)  { "\n?  " }
+  let(:prompt) { "\n?  " }
 
   subject do
     Readline.input = input
-    Readline.output = output_with_input
+    Readline.output = readline_output
     Class.new(HighLine) { include ApplianceConsole::Prompts }.new(input, output)
   end
 
@@ -608,18 +612,11 @@ describe ApplianceConsole::Prompts do
   end
 
   def expect_heard(strs, check_eof = true)
-    output_with_input.rewind
-    readline_output = output_with_input.read
-    if readline_output.empty?
-      strs = Array(strs).collect { |s| s == "" ? "\n" : s }.join
-    else
-      strs = Array(strs)
-      str1 = strs[0]
-      strs = strs[1..-1].collect { |s| s == "" ? "\n" : s }.join
-      first_output_correct = readline_output.include?(str1)
-      expect(first_output_correct).to be_truthy
-    end
-
+    readline_output.rewind
+    readline_output_content = readline_output.read
+    strs = Array(strs)
+    expect(readline_output_content).to include(strs.shift) unless readline_output_content.empty?
+    strs = strs.collect { |s| s == "" ? "\n" : s }.join
     expect(output.string).to eq(strs)
     expect { subject.ask("is there more") }.to raise_error(EOFError) if check_eof
     expect(input).to be_eof


### PR DESCRIPTION
**ISSUE**: User can't navigate input using arrow keys when answering question to appliance console

**BZ**: https://bugzilla.redhat.com/show_bug.cgi?id=1446249

\cc @gtanzillo @yrudman 

@miq-bot add-label bug,wip