### PR TITLE
[FINE] Disable connection reuse for WebSocket connections in Apache

### DIFF
--- a/lib/gems/pending/util/miq_apache/miq_apache.rb
+++ b/lib/gems/pending/util/miq_apache/miq_apache.rb
@@ -266,7 +266,13 @@ module MiqApache
 
       ports = Array(ports).sort.reverse
       ports.each do |port|
-        @raw_lines.insert(index + 1, "BalancerMember #{protocol}://0.0.0.0:#{port}\n")
+        # Temporarily disable the connection reuse for WebSockets for httpd version < 2.4.25
+        # https://bugzilla.redhat.com/show_bug.cgi?id=1404354
+        if protocol == 'ws'
+          @raw_lines.insert(index + 1, "BalancerMember #{protocol}://0.0.0.0:#{port} disablereuse=on\n")
+        else
+          @raw_lines.insert(index + 1, "BalancerMember #{protocol}://0.0.0.0:#{port}\n")
+        end
       end
       ports
     end
@@ -274,7 +280,7 @@ module MiqApache
     def remove_ports(ports, protocol)
       ports = Array(ports)
       ports.each do |port|
-        @raw_lines.delete_if { |line| line =~ /BalancerMember\s+#{protocol}:\/\/0\.0\.0\.0:#{port}$/ }
+        @raw_lines.delete_if { |line| line =~ /BalancerMember\s+#{protocol}:\/\/0\.0\.0\.0:#{port}( disablereuse=on)?$/ }
       end
       ports
     end

--- a/spec/util/miq_apache/conf_spec.rb
+++ b/spec/util/miq_apache/conf_spec.rb
@@ -86,10 +86,33 @@ describe MiqApache::Conf do
       @conf = MiqApache::Conf.new(@conf_file)
     end
 
+    context "with http as the protocol" do
+      it 'remove_ports should remove the line' do
+        before = @conf.raw_lines.dup
+        @conf.raw_lines = ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember http://0.0.0.0:3000\n", "</Proxy>\n"]
+        @conf.remove_ports(3000, "http")
+        expect(@conf.raw_lines).to eq(before)
+      end
+    end
+
     context "with other protocol than http" do
       it "add_ports should add the port with the given protocol" do
+        @conf.add_ports(3000, "xx")
+        expect(@conf.raw_lines).to eq(["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember xx://0.0.0.0:3000\n", "</Proxy>\n"])
+      end
+    end
+
+    context "with websocket as protocol" do
+      it 'add_ports should add the disablereuse=on suffix' do
         @conf.add_ports(3000, "ws")
-        expect(@conf.raw_lines).to eq(["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember ws://0.0.0.0:3000\n", "</Proxy>\n"])
+        expect(@conf.raw_lines).to eq(["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember ws://0.0.0.0:3000 disablereuse=on\n", "</Proxy>\n"])
+      end
+
+      it 'remove_ports should remove the line with a suffix' do
+        before = @conf.raw_lines.dup
+        @conf.raw_lines = ["<Proxy balancer://evmcluster/ lbmethod=byrequests>\n", "BalancerMember ws://0.0.0.0:3000 disablereuse=on\n", "</Proxy>\n"]
+        @conf.remove_ports(3000, "ws")
+        expect(@conf.raw_lines).to eq(before)
       end
     end
 


### PR DESCRIPTION
This is a temporary workaround for the issue described here:
https://bugzilla.redhat.com/show_bug.cgi?id=1404354

This can be reverted after httpd is updated to 2.4.25 or newer