### PR TITLE
Change log_hashes to log as a single log line.

### DIFF
--- a/lib/gems/pending/util/vmdb-logger.rb
+++ b/lib/gems/pending/util/vmdb-logger.rb
@@ -114,13 +114,14 @@ class VMDBLogger < Logger
     filter.uniq!
 
     values = YAML.dump(h).gsub(MiqPassword::REGEXP, "[FILTERED]")
-    values.split("\n").each do |l|
-      next if l[0...3] == '---'
+    values = values.split("\n").map do |l|
       if (key = filter.detect { |f| l.include?(f) })
         l.gsub!(/#{key}.*: (.+)/) { |m| m.gsub!($1, "[FILTERED]") }
       end
-      logger.send(level, "  #{l}")
-    end
+      l
+    end.join("\n")
+
+    logger.send(level, "\n#{values}")
   end
 
   def log_hashes(h, options = {})

--- a/lib/gems/pending/util/vmdb-logger.rb
+++ b/lib/gems/pending/util/vmdb-logger.rb
@@ -1,4 +1,6 @@
 require 'logger'
+require 'active_support/core_ext/object/try'
+require 'English'
 
 class VMDBLogger < Logger
   def initialize(*args)
@@ -104,6 +106,9 @@ class VMDBLogger < Logger
   end
 
   def self.log_hashes(logger, h, options = {})
+    require 'yaml'
+    require 'miq-password'
+
     level  = options[:log_level] || :info
     filter = Array(options[:filter]).flatten.compact.map(&:to_s) << "password"
     filter.uniq!


### PR DESCRIPTION
The container based JSON output will now have all of this information in
a single line allowing us to better process it.

@bdunne Please review.

This also cuts down on the 8000 log lines during boot by about 1200 lines.

---

**Before**

```
irb(main):002:0> logger = VMDBLogger.new(STDOUT)
=> #<VMDBLogger:0x007ff7f3d18240 ...>
irb(main):003:0> logger.log_hashes({a: 1, b: {c: {d: 3, e: 4}}})
[----] I, [2017-06-28T13:46:57.778921 #23752:3ffbf8c3f828]  INFO -- :   :a: 1
[----] I, [2017-06-28T13:46:57.778994 #23752:3ffbf8c3f828]  INFO -- :   :b:
[----] I, [2017-06-28T13:46:57.779010 #23752:3ffbf8c3f828]  INFO -- :     :c:
[----] I, [2017-06-28T13:46:57.779021 #23752:3ffbf8c3f828]  INFO -- :       :d: 3
[----] I, [2017-06-28T13:46:57.779030 #23752:3ffbf8c3f828]  INFO -- :       :e: 4
```

**After**

```
irb(main):002:0> logger = VMDBLogger.new(STDOUT)
=> #<VMDBLogger:0x007fdd38f61c70 ...>
irb(main):003:0> logger.log_hashes({a: 1, b: {c: {d: 3, e: 4}}})
[----] I, [2017-06-28T13:40:25.893586 #20008:3fee9b03f858]  INFO -- :
---
:a: 1
:b:
  :c:
    :d: 3
    :e: 4
```