### PR TITLE
handle PG::ConnectionBad and appliance console won't crash when provide invalid IP address

### DIFF
--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -136,6 +136,12 @@ module ApplianceConsole
 
       say("An #{node_state} #{rec["type"]} node (#{rec["name"]}) with the node number #{node_number} already exists")
       ask_yn?("Would you like to continue configuration by overwriting the existing node", "N")
+
+    rescue PG::Error => e
+      error_msg = "Failed to validate node number #{node_number}. #{e.message}"
+      say(error_msg)
+      Logging.logger.error(error_msg)
+      return false
     end
 
     private


### PR DESCRIPTION
**ISSUE**: The PG::ConnectionBad error is not handled, so if an invalid IP address is provided in database replication, standby, appliance console will crashed. Now it's fixed.
**BZ**: https://bugzilla.redhat.com/show_bug.cgi?id=1445819

\cc @yrudman 

@miq-bot add-label wip, bug