### PR TITLE
We need to kill httpd only when it is running

### DIFF
--- a/lib/gems/pending/util/miq_apache/miq_apache.rb
+++ b/lib/gems/pending/util/miq_apache/miq_apache.rb
@@ -51,7 +51,8 @@ module MiqApache
 
     def self.stop
       if ENV["CONTAINER"]
-        system("kill -WINCH $(pgrep -P 1 httpd)")
+        pid = `pgrep -P 1 httpd`.chomp.to_i
+        system("kill -WINCH #{pid}") if pid > 0
       else
         run_apache_cmd 'stop'
       end


### PR DESCRIPTION
```
Loading production environment (Rails 5.0.4)
irb(main):001:0> MiqApache::Control.stop
=> true
irb(main):002:0> Terminated
```

even though:
```
sh-4.2# kill -WINCH $(pgrep -P 1 httpd)
kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]
```