### PR TITLE
Remove the scl methods from PostgresAdmin

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -21,14 +21,6 @@ class PostgresAdmin
     ENV.fetch("APPLIANCE_PG_SERVICE")
   end
 
-  def self.scl_name
-    ENV.fetch('APPLIANCE_PG_SCL_NAME')
-  end
-
-  def self.scl_enable_prefix
-    "scl enable #{scl_name}"
-  end
-
   def self.package_name
     ENV.fetch('APPLIANCE_PG_PACKAGE_NAME')
   end

--- a/spec/util/postgres_admin_spec.rb
+++ b/spec/util/postgres_admin_spec.rb
@@ -9,7 +9,6 @@ describe PostgresAdmin do
 
     [%w(data_directory     APPLIANCE_PG_DATA            /some/path      true),
      %w(service_name       APPLIANCE_PG_SERVICE         postgresql          ),
-     %w(scl_name           APPLIANCE_PG_SCL_NAME        postgresql_scl      ),
      %w(package_name       APPLIANCE_PG_PACKAGE_NAME    postgresql-server   ),
      %w(template_directory APPLIANCE_TEMPLATE_DIRECTORY /some/path      true),
      %w(mount_point        APPLIANCE_PG_MOUNT_POINT     /mount/point    true)
@@ -23,11 +22,6 @@ describe PostgresAdmin do
           expect(result).to eql value
         end
       end
-    end
-
-    it ".scl_enable_prefix" do
-      ENV["APPLIANCE_PG_SCL_NAME"] = "postgresql92"
-      expect(described_class.scl_enable_prefix).to eql "scl enable postgresql92"
     end
 
     it ".logical_volume_path" do


### PR DESCRIPTION
These are no longer used as of d885a27cda71ea22622e8e85fdbb4d41b6d9ac3f