### PR TITLE
Remove Win32API

### DIFF
--- a/lib/gems/pending/util/extensions/miq-file.rb
+++ b/lib/gems/pending/util/extensions/miq-file.rb
@@ -1,5 +1,4 @@
 require 'sys-uname'
-require 'Win32API' if Sys::Platform::OS == :windows
 require 'util/runcmd'
 require 'uri'
 require 'util/MiqSockUtil'
@@ -7,26 +6,11 @@ require 'addressable'
 
 class File
   def self.paths_equal?(f1, f2)
-    if Sys::Platform::OS == :windows
-      # Note: The file needs to exist and be accessable for getShortFileName to work.
-      f1 = File.getShortFileName(f1).downcase
-      f2 = File.getShortFileName(f2).downcase
-    end
-
     File.expand_path(f1).tr("\\", "/") == File.expand_path(f2).tr("\\", "/")
   end
 
   def self.getShortFileName(longName)
-    if Sys::Platform::OS == :windows
-      size = 255
-      buffer = " " * 255
-      returnSize = Win32API.new("kernel32", "GetShortPathNameA", 'ppl', 'L').Call(longName,  buffer, size)
-      a = ""
-      a += buffer[0...returnSize]
-      return a
-    else
-      return longName
-    end
+    longName
   end
 
   def self.normalize(path)
@@ -43,9 +27,6 @@ class File
     case Sys::Platform::IMPL
     when :linux
       MiqUtil.runcmd("ls -lQ \"#{path}\"").split(" ")[4].to_i
-    when :mswin, :mingw
-      require 'disk/modules/MiqLargeFile'
-      MiqLargeFile.size(path)
     else
       File.size(path)
     end


### PR DESCRIPTION
Since we don't support running the app on Windows we can remove Win32API and cleanup these OS checks.

Followup to https://github.com/ManageIQ/manageiq/issues/1404