### PR TITLE
Remove obsolete method File.sizeEx

### DIFF
--- a/lib/gems/pending/util/extensions/miq-file.rb
+++ b/lib/gems/pending/util/extensions/miq-file.rb
@@ -1,19 +1,8 @@
-require 'sys-uname'
-require 'util/runcmd'
 require 'uri'
 require 'util/MiqSockUtil'
 require 'addressable'
 
 class File
-  # Extended File.size method to handle files over 2GB
-  def self.sizeEx(path)
-    case Sys::Platform::IMPL
-    when :linux
-      MiqUtil.runcmd("ls -lQ \"#{path}\"").split(" ")[4].to_i
-    else
-      File.size(path)
-    end
-  end
 
   def self.path_to_uri(file, hostname = nil)
     hostname ||= MiqSockUtil.getFullyQualifiedDomainName


### PR DESCRIPTION
Depends on removal of last usage in https://github.com/ManageIQ/manageiq-smartstate/pull/13