### PR TITLE
New version of linux_admin to fix static ipv6 after dhcp bugs

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "binary_struct",           "~> 2.1"
   s.add_runtime_dependency "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
   s.add_runtime_dependency "highline",                "~> 1.6.21" # Needed for the appliance_console
-  s.add_runtime_dependency "linux_admin",             "~>0.20.1"
+  s.add_runtime_dependency "linux_admin",             "~>0.20.2"
   s.add_runtime_dependency "log4r",                   "=1.1.8"
   s.add_runtime_dependency "memoist",                 "~>0.15.0"
   s.add_runtime_dependency "more_core_extensions",    "~>3.2"


### PR DESCRIPTION
Two bug fix related to set static ipv6 after a dhcp configuration, which have been fixed in new version of linux_admin
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1464994
https://bugzilla.redhat.com/show_bug.cgi?id=1464999

@miq-bot add-label bug

\cc @carbonin 