### PR TITLE
Don't clear the cache until we have a new value to cache

### DIFF
--- a/lib/gems/pending/util/extensions/miq-module.rb
+++ b/lib/gems/pending/util/extensions/miq-module.rb
@@ -26,15 +26,17 @@ class Module
         cache = $miq_cache_with_timeout[key]
 
         old_timeout = cache[:timeout]
-        cache.clear if force_reload || (old_timeout && Time.now.utc > old_timeout)
-        break cache[:value] unless cache.empty?
+        timeout_expired = !!old_timeout && (Time.now.utc > old_timeout)
+        break cache[:value] if (!force_reload && !timeout_expired && cache.key?(:value))
 
         new_timeout = timeout || 300 # 5 minutes
         new_timeout = new_timeout.call if new_timeout.kind_of?(Proc)
         new_timeout = Time.now.utc + new_timeout
+        new_value   = block.call
+        cache.clear
 
         cache[:timeout] = new_timeout
-        cache[:value]   = block.call
+        cache[:value]   = new_value
       end
     end
 

--- a/spec/util/extensions/miq-module_spec.rb
+++ b/spec/util/extensions/miq-module_spec.rb
@@ -41,6 +41,22 @@ describe Module do
       expect(test_module.default).to eq(value)
     end
 
+    it 'will return a prior cached value if resetting the value fails' do
+      $already_run = false
+      test_class.cache_with_timeout(:flapping_method) do
+        if $already_run == false
+          $already_run = true
+          5
+        else
+          raise "OOPS"
+        end
+      end
+
+      test_class.flapping_method(true)             # sets cache to 5
+      test_class.flapping_method(true) rescue nil  # blows up, doesn't reset cache
+      expect(test_class.flapping_method).to eq(5)  # returns prior cached value of 5
+    end
+
     it 'will not return the cached value when passed force_reload = true' do
       value = test_class.default(true)
       expect(test_class.default(true)).not_to eq(value)


### PR DESCRIPTION
The prior cache[:value] was being cleared too early.   If block.call
raised an exception, we lost the prior cached value.

A subsequent method call was checking only if the cache was non-empty, which it was,
since the cache[:timeout] was set.  We would then return a nil because cache[:value]
was never set when the exception occurred.

https://bugzilla.redhat.com/show_bug.cgi?id=1469307
https://bugzilla.redhat.com/show_bug.cgi?id=1468898