### PR TITLE
Remove obsolete File.normalize extension

### DIFF
--- a/lib/gems/pending/util/extensions/miq-file.rb
+++ b/lib/gems/pending/util/extensions/miq-file.rb
@@ -5,10 +5,6 @@ require 'util/MiqSockUtil'
 require 'addressable'
 
 class File
-  def self.normalize(path)
-    File.expand_path(path.gsub(/\\/, "/"))
-  end
-
   # Extended File.size method to handle files over 2GB
   def self.sizeEx(path)
     case Sys::Platform::IMPL


### PR DESCRIPTION
File.normalize was used only by SmartState VmConfig so we can move the
logic there.

Depends on: https://github.com/ManageIQ/manageiq-smartstate/pull/16