### PR TITLE
Only return the cached value if it exists.

### DIFF
--- a/lib/gems/pending/util/extensions/miq-module.rb
+++ b/lib/gems/pending/util/extensions/miq-module.rb
@@ -27,14 +27,15 @@ class Module
 
         old_timeout = cache[:timeout]
         cache.clear if force_reload || (old_timeout && Time.now.utc > old_timeout)
-        break cache[:value] unless cache.empty?
+        break cache[:value] if cache.key?(:value)
 
         new_timeout = timeout || 300 # 5 minutes
         new_timeout = new_timeout.call if new_timeout.kind_of?(Proc)
         new_timeout = Time.now.utc + new_timeout
+        new_value   = block.call
 
         cache[:timeout] = new_timeout
-        cache[:value]   = block.call
+        cache[:value]   = new_value
       end
     end
 


### PR DESCRIPTION
If the cache was cleared and an exception was raised when trying to set
the new `cache[:value]`, we'd end up setting the `cache[:timeout]` but
not the new value.  Any subsequent call would return a nil from
`cache[:value]` because `cache[:timeout]` exists, making `cache` non-empty.

The new code only returns from the cache if the :value key exists in the
`cache`.

Additionally, for consistency, we only set the `cache[:timeout]`
and `cache[:value]` after we've calculated these values, therefore the
`cache` doesn't get partially set.  This is not required but makes me
feel better.

https://bugzilla.redhat.com/show_bug.cgi?id=1469307
https://bugzilla.redhat.com/show_bug.cgi?id=1468898

This replaces https://github.com/ManageIQ/manageiq-gems-pending/pull/244