### PR TITLE
Add support for the external auth domain user attribute

### DIFF
--- a/lib/gems/pending/appliance_console/external_httpd_configuration.rb
+++ b/lib/gems/pending/appliance_console/external_httpd_configuration.rb
@@ -31,7 +31,8 @@ module ApplianceConsole
         "mail"        => "REMOTE_USER_EMAIL",
         "givenname"   => "REMOTE_USER_FIRSTNAME",
         "sn"          => "REMOTE_USER_LASTNAME",
-        "displayname" => "REMOTE_USER_FULLNAME"
+        "displayname" => "REMOTE_USER_FULLNAME",
+        "domainname"  => "REMOTE_USER_DOMAIN"
       }.freeze
 
       def template_directory


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1424618

This PR is paired with PR [15535](https://github.com/ManageIQ/manageiq/pull/15535) in the ManageIQ/manageiq repo. Both must be merged at the same time.

## Note:

This change requires new support in the underlying SSSD code. Updates were
required to provide the domain name when MiQ is configured to use External Authentication (Mode: External (httpd)

The BZs that track this work are:

[BZ 1425891](https://bugzilla.redhat.com/show_bug.cgi?id=1425891)
[BZ 1455254](https://bugzilla.redhat.com/show_bug.cgi?id=1455254)
The fixes for these BZs are targeted for RHEL 7.4 GA and CentOS 7.4

Therefor this change should not be merged until MiQ appliance builds migrate to RHEL 7.4 GA and CentOS 7.4

## Testing:

- With the associated PR in place use the appliance console to configure: _Configure External Authentication (httpd)_
- Configure the appliance for external authentication
- Add a valid group
- login with a valid user
- confirm the user record has a userid in _User Principal Name_ format 