### PR TITLE
realtime_block: log timings on exception in outermost block

### DIFF
--- a/lib/gems/pending/util/extensions/miq-benchmark.rb
+++ b/lib/gems/pending/util/extensions/miq-benchmark.rb
@@ -34,6 +34,10 @@ module Benchmark
         begin
           ret = realtime_store(hash, key, &block)
           return ret, hash
+        rescue Exception
+          # Don't let timings be lost on exception when there is nobody else to pick them up.
+          Logger.new($stderr).info("Exception in realtime_block #{key.inspect} - Timings: #{hash.inspect}")
+          raise
         ensure
           delete_current_realtime
         end

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -50,6 +50,6 @@ Gem::Specification.new do |s|
   s.add_development_dependency "rspec",                     "~> 3.5.0"
   s.add_development_dependency "simplecov"
   s.add_development_dependency "test-unit"
-  s.add_development_dependency "timecop",                   "~> 0.7.3"
+  s.add_development_dependency "timecop",                   "~> 0.9.1"
   s.add_development_dependency "xml-simple",                "~> 1.1.0"
 end


### PR DESCRIPTION
When realtime_block is aborted with exception, the timings are still there in the hash, so a higher level may log them.
Unless that is this was the outermost block, in which case they're lost.
This PR logs them in such case.

Example:
```
[----] E, [2017-08-07T15:04:08.145415 #14296:2aaca3b530cc] ERROR -- : MIQ(ManageIQ::Providers::Openshift::ContainerManager::Refresher#refresh) EMS: [scale-ocp-36-c03], id: [3] Refresh failed
[----] E, [2017-08-07T15:04:08.145736 #14296:2aaca3b530cc] ERROR -- : [KubeException]: Timed out connecting to server  Method:[block in method_missing]
[----] E, [2017-08-07T15:04:08.145855 #14296:2aaca3b530cc] ERROR -- : /home/bpaskinc/myenv/rbenv/versions/2.3.4/lib/ruby/gems/2.3.0/gems/kubeclient-2.4.0/lib/kubeclient/common.rb:117:in `rescue in handle_exception'
...
bin/rails:4:in `<main>'
[----] E, [2017-08-07T15:04:08.145951 #14296:2aaca3b530cc] ERROR -- : MIQ(ManageIQ::Providers::Openshift::ContainerManager::Refresher#refresh) EMS: [scale-ocp-36-c03], id: [3] Unable to perform refresh for the following targets:
[----] E, [2017-08-07T15:04:08.146105 #14296:2aaca3b530cc] ERROR -- : MIQ(ManageIQ::Providers::Openshift::ContainerManager::Refresher#refresh)  --- ManageIQ::Providers::Openshift::ContainerManager [scale-ocp-36-c03] id [3]
[----] I, [2017-08-07T15:04:08.236129 #14296:2aaca3b530cc]  INFO -- : MIQ(ManageIQ::Providers::Openshift::ContainerManager::Refresher#refresh) Refreshing all targets...Complete
[----] I, [2017-08-07T15:04:08.236201 #14296:2aaca3b530cc]  INFO -- : Exception in realtime_block :ems_total_refresh - Timings: {:collect_inventory_for_targets=>60.113999128341675, :ems_refresh=>60.11402702331543, :ems_total_refresh=>60.208136320114136}
```

* This is not water-tight against `Timeout.timeout`.
  Timeout inside the block logged:
  ```
  Benchmark.realtime_block(:sleep) { Timeout.timeout(3) { sleep(10) } }
  ```
  but outside it didn't:
  ```
  Timeout.timeout(3) { Benchmark.realtime_block(:sleep) { sleep(10) } }
  ```
  (See also https://github.com/ManageIQ/manageiq/issues/9642 for more Timeout woes)