### PR TITLE
Fix restart network error when set host name in pure ipv6 network

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -307,7 +307,7 @@ Static Network Configuration
             system_hosts.hostname = new_host
             system_hosts.set_loopback_hostname(new_host)
             system_hosts.save
-            LinuxAdmin::Service.new("network").restart
+
             press_any_key
           end
         end


### PR DESCRIPTION
ISSUE: In pure ipv6 network, after set hostname, appliance console will restart network. Currently we're using `systemctl restart network`, which can't successfully start network after stop it and cause appliance console crushed. But using NetworkManager is fine. As in https://access.redhat.com/solutions/783533 , network is considered as depreicate and we can update to use NetworkManager instead

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1475804

\cc @gtanzillo @yrudman 

@miq-bot add-label wip, bug