### PR TITLE
Allow httpd password to have dollar sign in it

### DIFF
--- a/lib/gems/pending/appliance_console/external_httpd_authentication.rb
+++ b/lib/gems/pending/appliance_console/external_httpd_authentication.rb
@@ -128,7 +128,7 @@ module ApplianceConsole
 
     def configure_ipa_http_service
       say("Configuring IPA HTTP Service and Keytab ...")
-      AwesomeSpawn.run!("/bin/echo \"#{@password}\" | /usr/bin/kinit #{@principal}")
+      AwesomeSpawn.run!("/usr/bin/kinit", :params => [@principal], :stdin_data => @password)
       service = Principal.new(:hostname => @host, :realm => realm, :service => "HTTP", :ca_name => "ipa")
       service.register
       AwesomeSpawn.run!(IPA_GETKEYTAB, :params => {"-s" => @ipaserver, "-k" => HTTP_KEYTAB, "-p" => service.name})


### PR DESCRIPTION
Having `$` sign inside double quotation for echo argument is interpreted as variable which need to be resolved.

https://bugzilla.redhat.com/show_bug.cgi?id=1438974

@miq-bot add-label bug

\cc @bdunne 