### PR TITLE
Bump sys-proctable

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -39,7 +39,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "pg",                      "~> 0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~> 0.1.0"
   s.add_runtime_dependency "rake",                    ">= 11.0"
-  s.add_runtime_dependency "sys-proctable",           "~> 1.1.3"
+  s.add_runtime_dependency "sys-proctable",           "~> 1.1.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.0.1"
   s.add_runtime_dependency "trollop",                 "~> 2.0"
   s.add_runtime_dependency "uuidtools",               "~> 2.1.3"


### PR DESCRIPTION
To force getting rid of the very annoying Fixnum warnings for Ruby 2.4

cc/ @djberg96