### PR TITLE
Configuring database hourly maintenance with appliance_console_cli tool

### DIFF
--- a/lib/gems/pending/appliance_console/cli.rb
+++ b/lib/gems/pending/appliance_console/cli.rb
@@ -13,6 +13,7 @@ require 'appliance_console/principal'
 require 'appliance_console/certificate'
 require 'appliance_console/certificate_authority'
 require 'appliance_console/logfile_configuration'
+require 'appliance_console/database_maintenance_hourly'
 
 # support for appliance_console methods
 unless defined?(say)
@@ -87,6 +88,10 @@ module ApplianceConsole
       options[:server]
     end
 
+    def db_hourly_maintenance?
+      options[:db_hourly_maintenance]
+    end
+
     def initialize(options = {})
       self.options = options
     end
@@ -117,6 +122,7 @@ module ApplianceConsole
         opt :username, "Database Username",  :type => :string,  :short => 'U', :default => "root"
         opt :password, "Database Password",  :type => :string,  :short => "p"
         opt :dbname,   "Database Name",      :type => :string,  :short => "d", :default => "vmdb_production"
+        opt :db_hourly_maintenance, "Configure database hourly maintenance", :type => :bool, :short => :none
         opt :standalone, "Run this server as a standalone database server", :type => :bool, :short => 'S'
         opt :key,      "Create encryption key",  :type => :boolean, :short => "k"
         opt :fetch_key, "SSH host with encryption key", :type => :string, :short => "K"
@@ -148,7 +154,7 @@ module ApplianceConsole
     def run
       Trollop.educate unless set_host? || key? || database? || tmp_disk? || log_disk? ||
                              uninstall_ipa? || install_ipa? || certs? || extauth_opts? ||
-                             time_zone? || set_server_state?
+                             time_zone? || set_server_state? || db_hourly_maintenance?
       if set_host?
         system_hosts = LinuxAdmin::Hosts.new
         system_hosts.hostname = options[:host]
@@ -159,6 +165,7 @@ module ApplianceConsole
       create_key if key?
       set_db if database?
       set_time_zone if time_zone?
+      config_db_hourly_maintenance if db_hourly_maintenance?
       config_tmp_disk if tmp_disk?
       config_log_disk if log_disk?
       uninstall_ipa if uninstall_ipa?
@@ -344,6 +351,12 @@ module ApplianceConsole
       else
         raise "Invalid server action"
       end
+    end
+
+    def config_db_hourly_maintenance
+      hourly = ApplianceConsole::DatabaseMaintenanceHourly.new
+      hourly.requested_activate = true
+      hourly.activate
     end
 
     def self.parse(args)


### PR DESCRIPTION
Configure database hourly maintenance with _appliance_console_cli_ tool. This feature is available using _appliance_console_, and could be useful for automated deployments.