### PR TITLE
Remove not used 'Prompts.ask_for_password_or_none' method

### DIFF
--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -135,11 +135,6 @@ module ApplianceConsole
       pass == "********" ? (default || "") : pass
     end
 
-    def ask_for_password_or_none(prompt, default = nil)
-      prompt += " ('none' for no value)" if default && !prompt.include?('none')
-      ask_for_password(prompt, default).gsub(NONE_REGEXP, "")
-    end
-
     def ask_for_string(prompt, default = nil)
       just_ask(prompt, default)
     end

--- a/spec/appliance_console/database_replication_primary_spec.rb
+++ b/spec/appliance_console/database_replication_primary_spec.rb
@@ -16,7 +16,6 @@ describe ApplianceConsole::DatabaseReplicationPrimary do
     allow(subject).to receive(:agree)
     allow(subject).to receive(:just_ask)
     allow(subject).to receive(:ask_for_ip_or_hostname)
-    allow(subject).to receive(:ask_for_password_or_none)
   end
 
   context "#ask_questions" do

--- a/spec/appliance_console/database_replication_spec.rb
+++ b/spec/appliance_console/database_replication_spec.rb
@@ -10,7 +10,6 @@ describe ApplianceConsole::DatabaseReplication do
     allow(subject).to receive(:clear_screen)
     allow(subject).to receive(:agree)
     allow(subject).to receive(:ask_for_ip_or_hostname)
-    allow(subject).to receive(:ask_for_password_or_none)
     allow(subject).to receive(:ask_for_password)
   end
 

--- a/spec/appliance_console/database_replication_standby_spec.rb
+++ b/spec/appliance_console/database_replication_standby_spec.rb
@@ -17,7 +17,6 @@ describe ApplianceConsole::DatabaseReplicationStandby do
     allow(subject).to receive(:agree)
     allow(subject).to receive(:just_ask)
     allow(subject).to receive(:ask_for_ip_or_hostname)
-    allow(subject).to receive(:ask_for_password_or_none)
   end
 
   context "#ask_questions" do

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -247,26 +247,6 @@ describe ApplianceConsole::Prompts do
       expect(subject.ask_for_password("prompt", "defaultpass")).to eq("defaultpass")
       expect_heard ["Enter the prompt: |********| ", ""]
     end
-
-    context "#or_none" do
-      it "should not append none if no default password" do
-        say "secret"
-        expect(subject.ask_for_password_or_none("prompt", nil)).to eq("secret")
-        expect_heard ["Enter the prompt: ", "******", ""]
-      end
-
-      it "should not botch passwords" do
-        say "secret"
-        expect(subject.ask_for_password_or_none("prompt", "defaultpass")).to eq("secret")
-        expect_heard ["Enter the prompt ('none' for no value): |********| ", "******", ""]
-      end
-
-      it "should support 'none' password" do
-        say "none"
-        expect(subject.ask_for_password_or_none("prompt", "defaultpass")).to eq("")
-        expect_heard ["Enter the prompt ('none' for no value): |********| ", "****", ""]
-      end
-    end
   end
 
   context "#ask_for_disk" do


### PR DESCRIPTION
Removed not used  `Prompts.ask_for_password_or_none`

This PR is follow-up to https://github.com/ManageIQ/manageiq-gems-pending/pull/125 - Do not allow to enter empty passwords when configuring DB

@miq-bot add-label appliance/console 