### PR TITLE
Kludge: doubly `ensure` clearing outermost realtime_block on Timeout

### DIFF
--- a/spec/util/extensions/miq-benchmark_spec.rb
+++ b/spec/util/extensions/miq-benchmark_spec.rb
@@ -1,8 +1,13 @@
 require 'util/extensions/miq-benchmark'
 require 'timecop'
+require 'timeout'
 
 describe Benchmark do
   after(:each) { Timecop.return }
+  after(:each) do
+    # Isolate other tests
+    Benchmark.delete_current_realtime if Benchmark.in_realtime_block?
+  end
 
   it '.realtime_store' do
     timings = {}
@@ -57,5 +62,43 @@ describe Benchmark do
       expect(Benchmark.in_realtime_block?).to be_truthy
     end
     expect(Benchmark.in_realtime_block?).to be_falsey
+  end
+
+  it "Timeout raising within .realtime_block" do
+    expect(Benchmark.in_realtime_block?).to be_falsey
+
+    places_outcomes = {}
+    1000.times do |i|
+      begin
+        # keep entering/exiting, abort ASAP
+        Timeout.timeout(1e-9) do
+          loop do
+            Benchmark.realtime_block(:test1) do
+              Benchmark.realtime_block(:test2) do
+              end
+              "result"
+            end
+          end
+        end
+      rescue Timeout::Error => e
+        # sortable compact stacks: realtime_block and children, outer first, strip directories, pad line numbers
+        interesting_depth = e.backtrace.rindex { |s| s =~ /in `realtime_block'/ } || 5
+        where = e.backtrace[0..interesting_depth].reverse
+        where = where.collect { |s| s.sub(%r{/.*/}, '').sub(/\d+:/) { |linenum| '%03d:' % linenum.to_i } }
+        places_outcomes[where] ||= {:cleaned => 0, :failed => 0}
+        if Benchmark.in_realtime_block?
+          places_outcomes[where][:failed] += 1
+          Benchmark.delete_current_realtime
+        else
+          places_outcomes[where][:cleaned] += 1
+        end
+      else
+        fail "impossible: escaped infinite loop without exception"
+      end
+    end
+
+    places_outcomes.sort.each do |where, outcomes|
+      puts "cleaned\t#{outcomes[:cleaned]}\tfailed\t#{outcomes[:failed]}\t#{where.join(' -> ')}"
+    end
   end
 end


### PR DESCRIPTION
**Based on #269**

Fixes https://github.com/ManageIQ/manageiq/issues/9642.
Timeout::Error is just one regular exception, it can be caught.  But it can strike anywhere.
`ensure` is not broken, if it hits inside `begin..ensure` that's fine, the cleanup runs.
BUT if it strikes after `ensure`, it can abort the cleanup!
Also it can strike between performing `current_realtime=` and even entering begin..ensure.
(Instrumenting the test to log stacktrace where exception hit confirms these are the 2 problematic points:
https://gist.github.com/cben/d5ea134a1f556023905488f1a6a756bf)

![The Hobbit - Bain gives Bard the Black Arrow "Timeout Errow"](https://user-images.githubusercontent.com/273688/29557338-6c043a4a-8731-11e7-9b98-c87de99dac54.png)

Good news is there is only one Timeout::~~Arrow~~Error!
(Unless we do nested Timeouts, and they expire in same millisecond.)
In this code the cleanup is safe to attempt twice.  At first I wanted to do something like this, which still had weak spots:
```diff
      self.current_realtime = hash if outermost
# 🏹 ➸ Weak spot here!
      begin
        ret = realtime_store(hash, key, &block)
        return ret, hash
      ensure
# 🏹   ➸ Weak spot here!  not covered by either begin..ensure
+       begin
          delete_current_realtime if outermost
+       ensure
+         delete_current_realtime if outermost && self.in_realtime_block?
+       end
      end
```
*This is why dragons have **overlapping** scales.*  A second begin..ensure covering the whole thing works, at least one `ensure` will complete uninterrupted. :-)
Successfully run 10M iterations :heavy_check_mark: 

Spec shamelessly stolen from @jrafanie's POC in https://github.com/ManageIQ/manageiq/issues/9642.
100k iterations take ~7seconds, doubling this repo's test suite :-(
10k usually missed the bug, it averages ~1/30k for me.
Can't narrow the time range down much (see gist above, wide time distribution to hit either spot).

@miq-bot add-label bug