### PR TITLE
Require version 0.18 or newer of ovirt gem

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -50,7 +50,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-sftp",                "~>2.1.2"
   s.add_runtime_dependency "nokogiri",                "~>1.7.2"
   s.add_runtime_dependency "openscap",                "~>0.4.3"
-  s.add_runtime_dependency "ovirt",                   "~>0.17.0"
+  s.add_runtime_dependency "ovirt",                   "~>0.18.0"
   s.add_runtime_dependency "parallel",                "~>1.9" # For OvirtInventory
   s.add_runtime_dependency "pg",                      "~>0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~>0.1.0"


### PR DESCRIPTION
Version 0.18 or newer of the 'ovirt' gem is needed in order to work
correctly with custom TLS trusted CA certificates.

This patch addresses the following bug:

  Service order request for VM provision from template fail on SSL Certificate verification
  https://bugzilla.redhat.com/1483303