### PR TITLE
Change log_hashes to log hash-like objects properly

### DIFF
--- a/lib/gems/pending/util/vmdb-logger.rb
+++ b/lib/gems/pending/util/vmdb-logger.rb
@@ -113,7 +113,7 @@ class VMDBLogger < Logger
     filter = Array(options[:filter]).flatten.compact.map(&:to_s) << "password"
     filter.uniq!
 
-    values = YAML.dump(h).gsub(MiqPassword::REGEXP, "[FILTERED]")
+    values = YAML.dump(h.to_hash).gsub(MiqPassword::REGEXP, "[FILTERED]")
     values = values.split("\n").map do |l|
       if (key = filter.detect { |f| l.include?(f) })
         l.gsub!(/#{key}.*: (.+)/) { |m| m.gsub!($1, "[FILTERED]") }

--- a/spec/util/vmdb-logger_spec.rb
+++ b/spec/util/vmdb-logger_spec.rb
@@ -66,6 +66,20 @@ describe VMDBLogger do
       buffer.rewind
       expect(buffer.read).to include(":password_for_important_thing: [FILTERED]")
     end
+
+    it "handles logging hash-like classes" do
+      require "active_support/core_ext/hash"
+      hash = ActiveSupport::HashWithIndifferentAccess.new(:a => 1, :b => {:c => 3})
+      logger.log_hashes(hash)
+
+      buffer.rewind
+      expect(buffer.read).to include(<<-EOS)
+---
+a: 1
+b:
+  c: 3
+      EOS
+    end
   end
 
   it ".contents with no log returns empty string" do


### PR DESCRIPTION
This will also log Config::Options properly, but I didn't want to include the config gem because it messes with global state.  HWIA showed the same problems, and active support is already a dependency, so it will suffice.