### PR TITLE
Cleanup after specs: Tempfiles, Readline redirection

### DIFF
--- a/spec/appliance_console/database_maintenance_hourly_spec.rb
+++ b/spec/appliance_console/database_maintenance_hourly_spec.rb
@@ -40,7 +40,7 @@ describe ApplianceConsole::DatabaseMaintenanceHourly do
       end
 
       after do
-        FileUtils.rm_f(@test_hourly_cron.path)
+        @test_hourly_cron.close!
       end
 
       it "returns true when un-configure is confirmed" do
@@ -92,7 +92,7 @@ describe ApplianceConsole::DatabaseMaintenanceHourly do
       end
 
       after do
-        FileUtils.rm_f(@test_hourly_cron.path)
+        @test_hourly_cron.close!
       end
 
       it "removes the existing hourly cron job" do

--- a/spec/appliance_console/database_maintenance_periodic_spec.rb
+++ b/spec/appliance_console/database_maintenance_periodic_spec.rb
@@ -10,7 +10,7 @@ describe ApplianceConsole::DatabaseMaintenancePeriodic do
   end
 
   after do
-    FileUtils.rm_f(@test_crontab1.path)
+    @test_crontab1.close!
   end
 
   describe "#confirm" do
@@ -69,7 +69,7 @@ describe ApplianceConsole::DatabaseMaintenancePeriodic do
       end
 
       after do
-        FileUtils.rm_f(@test_crontab.path)
+        @test_crontab.close!
       end
 
       let(:expected_crontab_file) do
@@ -115,7 +115,7 @@ describe ApplianceConsole::DatabaseMaintenancePeriodic do
       end
 
       after do
-        FileUtils.rm_f(@test_crontab.path)
+        @test_crontab.close!
       end
 
       it "removes the periodic database maintenance entries from the crontab" do

--- a/spec/appliance_console/external_httpd_authentication_spec.rb
+++ b/spec/appliance_console/external_httpd_authentication_spec.rb
@@ -105,7 +105,7 @@ describe ApplianceConsole::ExternalHttpdAuthentication do
     end
 
     after do
-      FileUtils.rm_f(@test_kerberos_config.path)
+      @test_kerberos_config.close!
     end
 
     it "saves a backup copy of the kerberos config file" do

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -9,15 +9,19 @@ require "linux_admin"
 
 describe ApplianceConsole::Prompts do
   let(:input) do
-    temp_stdin = Tempfile.new("temp_stdin")
-    File.open(temp_stdin.path, 'w+')
+    @temp_stdin = Tempfile.new("temp_stdin")
+    File.open(@temp_stdin.path, 'w+')
   end
   let(:readline_output) do
-    temp_stdout = Tempfile.new("temp_stdout")
-    File.open(temp_stdout.path, 'w+')
+    @temp_stdout = Tempfile.new("temp_stdout")
+    File.open(@temp_stdout.path, 'w+')
   end
   let(:output) { StringIO.new }
   let(:prompt) { "\n?  " }
+  after do
+    @temp_stdin.close! if @temp_stdin
+    @temp_stdout.close! if @temp_stdout
+  end
 
   subject do
     Readline.input = input

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -29,6 +29,12 @@ describe ApplianceConsole::Prompts do
     Class.new(HighLine) { include ApplianceConsole::Prompts }.new(input, output)
   end
 
+  after do
+    # best-guess cleanup: Readline has .input=, .output= but no .input, .output
+    Readline.input = STDIN
+    Readline.output = STDOUT
+  end
+
   # net/ssh messes with track_eof
   # we need it for testing
   # set it back after we are done


### PR DESCRIPTION
Both close and unlink all Tempfiles created in specs.
Helpful for #263 to avoid https://bugs.ruby-lang.org/issues/13876, and good practice anyway.
@jrafanie please review