### PR TITLE
[FINE] Treat Resource Group as a String not an Object

### DIFF
--- a/lib/gems/pending/MiqVm/miq_azure_vm.rb
+++ b/lib/gems/pending/MiqVm/miq_azure_vm.rb
@@ -15,7 +15,7 @@ class MiqAzureVm < MiqVm
     if args[:image_uri]
       @uri = args[:image_uri]
     elsif args[:resource_group] && args[:name]
-      vm_obj = vm_svc.get(@name, @resource_group.name)
+      vm_obj = vm_svc.get(@name, @resource_group)
       os_disk = vm_obj.properties.storage_profile.os_disk
       if vm_obj.managed_disk?
         #
@@ -102,7 +102,7 @@ class MiqAzureVm < MiqVm
     disk_format              = @vmConfig.getHash["#{disk_tag}.format"]
     disk_info.format         = disk_format unless disk_format.blank?
     disk_info.rawDisk        = true
-    disk_info.resource_group = @resource_group.name
+    disk_info.resource_group = @resource_group
     disk_info
   end
 

--- a/spec/miq_vm/miq_azure_vm_image_spec.rb
+++ b/spec/miq_vm/miq_azure_vm_image_spec.rb
@@ -15,8 +15,7 @@ describe MiqAzureVm do
     @subscription_id      = @test_env[:azure_subscription_id]
     @image_name           = @test_env[:image_name]
     @image_uri            = @test_env[:image_uri]
-    resource_group_json   = '{"name": "#{@test_env[:image_resource_group]}"}'
-    @image_resource_group = Azure::Armrest::ResourceGroup.new(resource_group_json)
+    @image_resource_group = @test_env[:image_resource_group]
 
     @test_env.ensure_recording_dir_exists
   end

--- a/spec/miq_vm/miq_azure_vm_instance_spec.rb
+++ b/spec/miq_vm/miq_azure_vm_instance_spec.rb
@@ -14,8 +14,7 @@ describe MiqAzureVm do
     @tenant_id               = @test_env[:azure_tenant_id]
     @subscription_id         = @test_env[:azure_subscription_id]
     @instance_name           = @test_env[:instance_name]
-    resource_group_json      = "{\"name\": \"#{@test_env[:instance_resource_group]}\"}"
-    @instance_resource_group = Azure::Armrest::ResourceGroup.new(resource_group_json)
+    @instance_resource_group = @test_env[:instance_resource_group]
 
     @test_env.ensure_recording_dir_exists
   end


### PR DESCRIPTION
A previous change assumed that a PR had been backported from Fine to upstream converting
Resource Groups to objects which had to be dereferenced to get to the name attribute.
This PR had not been backported so we need to treat the value as a String.

This is for high priority BZ https://bugzilla.redhat.com/show_bug.cgi?id=1475540

@roliveri please review.  Another pr against manageiq-providers-azure will be added with similar changes.