### PR TITLE
Specify rhel7 as the scap security guide platform

### DIFF
--- a/lib/gems/pending/appliance_console/scap.rb
+++ b/lib/gems/pending/appliance_console/scap.rb
@@ -12,7 +12,7 @@ module ApplianceConsole
         require 'yaml'
         scap_config = YAML.load_file(yaml_filename)
         begin
-          LinuxAdmin::Scap.new.lockdown(*scap_config['rules'], scap_config['values'])
+          LinuxAdmin::Scap.new("rhel7").lockdown(*scap_config['rules'], scap_config['values'])
         rescue => e
           say("Configuration failed: #{e.message}")
         else

--- a/lib/gems/pending/appliance_console/scap.rb
+++ b/lib/gems/pending/appliance_console/scap.rb
@@ -31,7 +31,7 @@ module ApplianceConsole
       if !LinuxAdmin::Scap.openscap_available?
         say("OpenSCAP has not been installed")
         false
-      elsif !LinuxAdmin::Scap.ssg_available?
+      elsif !LinuxAdmin::Scap.ssg_available?("rhel7")
         say("SCAP Security Guide has not been installed")
         false
       else

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "binary_struct",           "~> 2.1"
   s.add_runtime_dependency "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
   s.add_runtime_dependency "highline",                "~> 1.6.21" # Needed for the appliance_console
-  s.add_runtime_dependency "linux_admin",             "~> 0.20.2"
+  s.add_runtime_dependency "linux_admin",             "~> 1.0"
   s.add_runtime_dependency "log4r",                   "=  1.1.8"
   s.add_runtime_dependency "memoist",                 "~> 0.15.0"
   s.add_runtime_dependency "more_core_extensions",    "~> 3.4"


### PR DESCRIPTION
Requires https://github.com/ManageIQ/linux_admin/pull/191 and https://github.com/ManageIQ/linux_admin/pull/192

https://bugzilla.redhat.com/show_bug.cgi?id=1493193