### PR TITLE
Force to use different partition for db

### DIFF
--- a/lib/gems/pending/appliance_console/database_replication_standby.rb
+++ b/lib/gems/pending/appliance_console/database_replication_standby.rb
@@ -30,7 +30,7 @@ module ApplianceConsole
       clear_screen
       say("Establish Replication Standby Server\n")
       return false if !data_dir_empty? && !confirm_data_resync
-      self.disk = ask_for_disk("Standby database disk")
+      self.disk = ask_for_disk("Standby database disk", true, false)
       ask_for_unique_cluster_node_number
       ask_for_database_credentials
       ask_for_standby_host

--- a/lib/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/internal_database_configuration.rb
@@ -66,7 +66,7 @@ module ApplianceConsole
     end
 
     def choose_disk
-      @disk = ask_for_disk("database disk")
+      @disk = ask_for_disk("database disk", true, false)
     end
 
     def initialize_postgresql_disk

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -143,12 +143,13 @@ module ApplianceConsole
       just_ask(prompt, default, INT_REGEXP, "an integer", Integer) { |q| q.in = range if range }
     end
 
-    def ask_for_disk(disk_name, verify = true)
+    def ask_for_disk(disk_name, verify = true, allow_none = true)
       require "linux_admin"
       disks = LinuxAdmin::Disk.local.select { |d| d.partitions.empty? }
 
       if disks.empty?
         say "No partition found for #{disk_name}. You probably want to add an unpartitioned disk and try again."
+        raise MiqSignalError unless allow_none
       else
         default_choice = disks.size == 1 ? "1" : nil
         disk = ask_with_menu(

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -291,6 +291,13 @@ describe ApplianceConsole::Prompts do
           "No partition found for database disk. You probably want to add an unpartitioned disk and try again.", ""
         ]
       end
+
+      it "should raise an exception if not allow none" do
+        expect { subject.ask_for_disk("database disk", true, false) }.to raise_error(MiqSignalError)
+        expect_heard [
+          "No partition found for database disk. You probably want to add an unpartitioned disk and try again."
+        ]
+      end
     end
 
     context "with one disk" do

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -295,7 +295,7 @@ describe ApplianceConsole::Prompts do
       it "should raise an exception if not allow none" do
         expect { subject.ask_for_disk("database disk", true, false) }.to raise_error(MiqSignalError)
         expect_heard [
-          "No partition found for database disk. You probably want to add an unpartitioned disk and try again."
+          "No partition found for database disk. You probably want to add an unpartitioned disk and try again.\n"
         ]
       end
     end


### PR DESCRIPTION
ISSUE:
We should not allow using same partition for OS and database.
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1425153

\cc @gtanzillo @yrudman @carbonin 

@miq-bot add-label wip,bug