### PR TITLE
internal database must be set with dbdisk option in ap and in cli

### DIFF
--- a/lib/gems/pending/appliance_console/cli.rb
+++ b/lib/gems/pending/appliance_console/cli.rb
@@ -200,6 +200,7 @@ module ApplianceConsole
         :disk              => disk_from_string(options[:dbdisk]),
         :run_as_evm_server => !options[:standalone]
       }.delete_if { |_n, v| v.nil? })
+      config.check_disk_is_mount_point
 
       # create partition, pv, vg, lv, ext4, update fstab, mount disk
       # initdb, relabel log directory for selinux, update configs,
@@ -212,6 +213,9 @@ module ApplianceConsole
 
       # enable/start related services
       config.post_activation
+    rescue RuntimeError => e
+      say e.message
+      say "Failed to configure internal database"
     end
 
     def set_external_db

--- a/spec/appliance_console/internal_database_configuration_spec.rb
+++ b/spec/appliance_console/internal_database_configuration_spec.rb
@@ -34,6 +34,25 @@ describe ApplianceConsole::InternalDatabaseConfiguration do
     @config.choose_disk
   end
 
+  context "#check_disk_is_mount_point" do
+    it "not raise error if disk is given" do
+      expect(@config).to receive(:disk).and_return("/x")
+      @config.check_disk_is_mount_point
+    end
+
+    it "not raise error if no disk given but mount point for database is really a mount point" do
+      expect(@config).to receive(:disk).and_return(nil)
+      expect(@config).to receive(:pg_mount_point?).and_return(true)
+      @config.check_disk_is_mount_point
+    end
+
+    it "raise error if no disk given and not a mount point" do
+      expect(@config).to receive(:disk).and_return(nil)
+      expect(@config).to receive(:pg_mount_point?).and_return(false)
+      expect { @config.check_disk_is_mount_point }.to raise_error(RuntimeError, "The disk for database must be a mount point")
+    end
+  end
+
   it ".postgresql_template" do
     allow(PostgresAdmin).to receive_messages(:data_directory     => Pathname.new("/var/lib/pgsql/data"))
     allow(PostgresAdmin).to receive_messages(:template_directory => Pathname.new("/opt/manageiq/manageiq-appliance/TEMPLATE"))


### PR DESCRIPTION
ISSUE:
When setting internal database in appliance console cli, the user can set without given a --dbdisk option, which is not supported.
BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1431815
https://bugzilla.redhat.com/show_bug.cgi?id=1425153

\cc @yrudman @gtanzillo 

@miq-bot add-label wip,bug