### PR TITLE
Update nokogiri to a more secure version.

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "more_core_extensions",    "~> 3.4"
   s.add_runtime_dependency "net-scp",                 "~> 1.2.1"
   s.add_runtime_dependency "net-sftp",                "~> 2.1.2"
-  s.add_runtime_dependency "nokogiri",                "~> 1.7.2"
+  s.add_runtime_dependency "nokogiri",                "~> 1.8.1"
   s.add_runtime_dependency "pg",                      "~> 0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~> 0.1.0"
   s.add_runtime_dependency "rake",                    ">= 11.0"


### PR DESCRIPTION
With the introduction of the following security vulnerability on libxml2 (a huge dependency of nokogiri):

https://access.redhat.com/security/cve/cve-2017-9050

`manageiq-gems-pending` should strive to try and use the latest version of the nokogiri gem to avoid including this vulnerability in dependencies of it.