### PR TITLE
Revert "Merge pull request #278 from NickLaMuro/update_nokogiri"

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "more_core_extensions",    "~> 3.4"
   s.add_runtime_dependency "net-scp",                 "~> 1.2.1"
   s.add_runtime_dependency "net-sftp",                "~> 2.1.2"
-  s.add_runtime_dependency "nokogiri",                "~> 1.8.1"
+  s.add_runtime_dependency "nokogiri",                "~> 1.7.2"
   s.add_runtime_dependency "pg",                      "~> 0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~> 0.1.0"
   s.add_runtime_dependency "rake",                    ">= 11.0"


### PR DESCRIPTION
This reverts commit 1a2599a2bcf863efd4be71bb56b606fab8c59e8b, reversing changes made to 795d14e8b47132944bab3331e1b6f2b916fb7c97.

The [change in azure-armrest](https://github.com/ManageIQ/azure-armrest/pull/325) is necessary for this to not break the build in `manageiq`, so this will need to be "un-reverted" once that is done.