### PR TITLE
Update nokogiri to a more secure version. Part Deux

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -35,7 +35,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "more_core_extensions",    "~> 3.4"
   s.add_runtime_dependency "net-scp",                 "~> 1.2.1"
   s.add_runtime_dependency "net-sftp",                "~> 2.1.2"
-  s.add_runtime_dependency "nokogiri",                "~> 1.7.2"
+  s.add_runtime_dependency "nokogiri",                "~> 1.8.1"
   s.add_runtime_dependency "pg",                      "~> 0.18.2"
   s.add_runtime_dependency "pg-dsn_parser",           "~> 0.1.0"
   s.add_runtime_dependency "rake",                    ">= 11.0"


### PR DESCRIPTION
Returns the changes from 81366a1 now that azure-armrest has been updated to v0.8.4 with relaxed nokogiri requirements.  Since `manageiq-providers-azure` has a version requirement of `~> 0.8.3`, it will autoupdate along with this change when it is merged in and the user re `bin/bundle updates`/`bin/update`'s.

Links
-----
* https://github.com/ManageIQ/manageiq-gems-pending/pull/278
* https://github.com/ManageIQ/manageiq-gems-pending/pull/279