### PR TITLE
must give password to set db in cli

### DIFF
--- a/lib/gems/pending/appliance_console/cli.rb
+++ b/lib/gems/pending/appliance_console/cli.rb
@@ -182,11 +182,16 @@ module ApplianceConsole
 
     def set_db
       raise "No encryption key (v2_key) present" unless key_configuration.key_exist?
+      raise "Must provide a password to set database" unless password?
       if local?
         set_internal_db
       else
         set_external_db
       end
+    end
+
+    def password?
+      options[:password] && !options[:password].strip.empty?
     end
 
     def set_internal_db

--- a/lib/gems/pending/appliance_console/cli.rb
+++ b/lib/gems/pending/appliance_console/cli.rb
@@ -182,7 +182,7 @@ module ApplianceConsole
 
     def set_db
       raise "No encryption key (v2_key) present" unless key_configuration.key_exist?
-      raise "Must provide a password to set database" unless password?
+      raise "A password is required to configure a database" unless password?
       if local?
         set_internal_db
       else

--- a/spec/appliance_console/cli_spec.rb
+++ b/spec/appliance_console/cli_spec.rb
@@ -32,7 +32,7 @@ describe ApplianceConsole::Cli do
   end
 
   it "should set database host to localhost if running locally" do
-    subject.parse(%w(--internal -r 1 --dbdisk x))
+    subject.parse(%w(--internal -r 1 --dbdisk x --password pass))
     expect_v2_key
     expect(subject).to receive(:disk_from_string).with('x').and_return('/dev/x')
     expect(subject).to receive(:say)
@@ -40,6 +40,7 @@ describe ApplianceConsole::Cli do
       .with(:region            => 1,
             :database          => 'vmdb_production',
             :username          => 'root',
+            :password          => 'pass',
             :interactive       => false,
             :disk              => '/dev/x',
             :run_as_evm_server => true)
@@ -153,6 +154,12 @@ describe ApplianceConsole::Cli do
       .and_return(double(:activate => true, :post_activation => true))
 
     subject.run
+  end
+
+  it "should not allow empty password in setting database" do
+    subject.parse(%w(--internal --username user -r 1 --dbdisk x))
+    expect_v2_key
+    expect { subject.run }.to raise_error(RuntimeError, "A password is required to configure a database")
   end
 
   context "#ipa" do


### PR DESCRIPTION
ISSUE: Currently we allow user to set up database in appliance console cli without given a password, which should be disallowed. This is part of BZ https://bugzilla.redhat.com/show_bug.cgi?id=1431815
Another part (disallow --internal without --dbdisk) is fixed in https://github.com/ManageIQ/manageiq-gems-pending/pull/277

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1431815#c2

\cc @yrudman @carbonin @gtanzillo 

@miq-bot add-label wip, bug