### PR TITLE
[WIP] Enable keyboard navigation when ask menu, ask y/n

### DIFF
--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -66,7 +66,7 @@ module ApplianceConsole
         q.readline = true
         q.default = default if default
       end
-      validator = ->(p) { (p.blank? && default) || %(y n).include?(p.downcase[0]) }
+      validator = ->(p) { (p.blank? && default) || (!p.blank? && %(y n).include?(p.downcase[0])) }
       until validator.call(answer.to_s)
         say(error_msg)
         answer = ask("?  ") do |q|

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -208,9 +208,10 @@ module ApplianceConsole
       end
     end
 
-    def just_agree(prompt, character = nil)
-      agree(prompt, character) do |q|
+    def just_agree(prompt, default = nil)
+      agree(prompt) do |q|
         q.readline = true
+        q.default = default if default
         yield q if block_given?
       end
     end

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -208,7 +208,7 @@ module ApplianceConsole
       end
     end
 
-    def just_agree(prompt, default = nil)
+    def just_ask_yn?(prompt, default = nil)
       agree(prompt) do |q|
         q.readline = true
         q.default = default if default

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -62,9 +62,9 @@ module ApplianceConsole
         q.readline = true
         q.default = default if default
       end
-      validator = lambda { |p| (p.blank? && default) || %(y n).include?(p.downcase[0]) }
-      while !validator.(answer.to_s)
-        puts "Please provide yes or no"
+      validator = ->(p) { (p.blank? && default) || %(y n).include?(p.downcase[0]) }
+      until validator.call(answer.to_s)
+        say("Please provide yes or no")
         answer = ask("?  ") do |q|
           q.readline = true
           q.default = defualt if default

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -54,11 +54,12 @@ module ApplianceConsole
 
     def are_you_sure?(clarifier = nil)
       clarifier = " you want to #{clarifier}" if clarifier && !clarifier.include?("want")
-      agree("Are you sure#{clarifier}? (Y/N): ")
+      just_agree("Are you sure#{clarifier}? (Y/N): ")
     end
 
     def ask_yn?(prompt, default = nil)
       ask("#{prompt}? (Y/N): ") do |q|
+        q.readline = true
         q.default = default if default
         q.validate = ->(p) { (p.blank? && default) || %w(y n).include?(p.downcase[0]) }
         q.responses[:not_valid] = "Please provide yes or no."
@@ -185,6 +186,7 @@ module ApplianceConsole
       default = default_to_index(default, options)
       selection = nil
       choose do |menu|
+        menu.readline     = true
         menu.default      = default
         menu.index        = :number
         menu.index_suffix = ") "
@@ -202,6 +204,13 @@ module ApplianceConsole
         q.default = default.to_s if default
         q.validate = validate if validate
         q.responses[:not_valid] = error_text ? "Please provide #{error_text}" : "Please provide in the specified format"
+        yield q if block_given?
+      end
+    end
+
+    def just_agree(prompt, character = nil)
+      agree(prompt, character) do |q|
+        q.readline = true
         yield q if block_given?
       end
     end

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -54,10 +54,14 @@ module ApplianceConsole
 
     def are_you_sure?(clarifier = nil)
       clarifier = " you want to #{clarifier}" if clarifier && !clarifier.include?("want")
-      ask_yn?("Are you sure#{clarifier}", nil, "Please enter \"yes\" or \"no\"")
+      just_ask_yn?("Are you sure#{clarifier}", nil, "Please enter \"yes\" or \"no\"")
     end
 
-    def ask_yn?(prompt, default = nil, error_msg = "Please provide yes or no")
+    def ask_yn?(prompt, default = nil)
+      just_ask_yn?(prompt, default)
+    end
+
+    def just_ask_yn?(prompt, default = nil, error_msg = "Please provide yes or no")
       answer = ask("#{prompt}? (Y/N): ") do |q|
         q.readline = true
         q.default = default if default

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -193,7 +193,6 @@ module ApplianceConsole
       default = default_to_index(default, options)
       selection = nil
       choose do |menu|
-        menu.readline     = true
         menu.default      = default
         menu.index        = :number
         menu.index_suffix = ") "

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -54,17 +54,17 @@ module ApplianceConsole
 
     def are_you_sure?(clarifier = nil)
       clarifier = " you want to #{clarifier}" if clarifier && !clarifier.include?("want")
-      ask_yn?("Are you sure#{clarifier}")
+      ask_yn?("Are you sure#{clarifier}", nil, "Please enter \"yes\" or \"no\"")
     end
 
-    def ask_yn?(prompt, default = nil)
+    def ask_yn?(prompt, default = nil, error_msg = "Please provide yes or no")
       answer = ask("#{prompt}? (Y/N): ") do |q|
         q.readline = true
         q.default = default if default
       end
       validator = ->(p) { (p.blank? && default) || %(y n).include?(p.downcase[0]) }
       until validator.call(answer.to_s)
-        say("Please provide yes or no")
+        say(error_msg)
         answer = ask("?  ") do |q|
           q.readline = true
           q.default = defualt if default

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -54,14 +54,14 @@ module ApplianceConsole
 
     def are_you_sure?(clarifier = nil)
       clarifier = " you want to #{clarifier}" if clarifier && !clarifier.include?("want")
-      just_ask_yn?("Are you sure#{clarifier}", nil, "Please enter \"yes\" or \"no\"")
+      just_ask_yn?("Are you sure#{clarifier}", nil, "Please enter \"yes\" or \"no\".")
     end
 
     def ask_yn?(prompt, default = nil)
       just_ask_yn?(prompt, default)
     end
 
-    def just_ask_yn?(prompt, default = nil, error_msg = "Please provide yes or no")
+    def just_ask_yn?(prompt, default = nil, error_msg = "Please provide yes or no.")
       answer = ask("#{prompt}? (Y/N): ") do |q|
         q.readline = true
         q.default = default if default

--- a/spec/appliance_console/prompts_spec.rb
+++ b/spec/appliance_console/prompts_spec.rb
@@ -133,7 +133,7 @@ describe ApplianceConsole::Prompts do
       error = %(Please enter "yes" or "no".\n)
       say %w(um yes)
       expect(subject.are_you_sure?).to be_truthy
-      expect_heard [prompt + error, prompt]
+      expect_heard [prompt, error, prompt]
     end
 
     it "should ask are you sure with clarifier" do
@@ -428,7 +428,7 @@ describe ApplianceConsole::Prompts do
       error = "Please provide yes or no."
       say %w(x z yes)
       expect(subject.ask_yn?("prompt")).to be_truthy
-      expect_heard ["prompt? (Y/N): ", error, prompt + error, prompt]
+      expect_heard ["prompt? (Y/N): ", error, prompt, error, prompt]
     end
 
     it "should respond to no" do


### PR DESCRIPTION
ISSUE:
Currently using arrow keys to navigate through input in appliance console is only support in long string input. Add support for that in asking for a menu choice and ask yes/no. See most recent comment from Luke.

BZ:
https://bugzilla.redhat.com/show_bug.cgi?id=1446249

\cc @yrudman @carbonin @gtanzillo 
@miq-bot add-label wip, bug