### PR TITLE
Allow ipv6 address as dns when setting static ipv4 

### DIFF
--- a/lib/gems/pending/appliance_console.rb
+++ b/lib/gems/pending/appliance_console.rb
@@ -195,8 +195,8 @@ To modify the configuration, use a web browser to access the management page.
           new_ip   = ask_for_ipv4("IP Address", ip)
           new_mask = ask_for_ipv4("Netmask", mask)
           new_gw   = ask_for_ipv4("Gateway", gw)
-          new_dns1 = ask_for_ipv4("Primary DNS", dns1)
-          new_dns2 = ask_for_ipv4_or_none("Secondary DNS (Enter 'none' for no value)")
+          new_dns1 = ask_for_ip("Primary DNS", dns1)
+          new_dns2 = ask_for_ip_or_none("Secondary DNS (Enter 'none' for no value)")
 
           new_search_order = ask_for_many("domain", "Domain search order", order)
 

--- a/lib/gems/pending/appliance_console/prompts.rb
+++ b/lib/gems/pending/appliance_console/prompts.rb
@@ -73,6 +73,10 @@ module ApplianceConsole
       just_ask(prompt, default, validate, error_text, &block)
     end
 
+    def ask_for_ip_or_none(prompt, default = nil)
+      ask_for_ip(prompt, default, Regexp.union(NONE_REGEXP, IP_REGEXP)).gsub(NONE_REGEXP, "")
+    end
+
     def ask_for_ipv4(prompt, default)
       ask_for_ip(prompt, default, IPV4_REGEXP)
     end


### PR DESCRIPTION
ISSUE:
When setting ipv4 static network in appliance console, we didn't allow ipv6 as dns. Now it's allowed.
BZ:
allow ipv6 address as dns when setting static ipv4 

\cc @yrudman @gtanzillo 
@miq-bot add-label wip, bug