### PR TITLE
Pass a string to mount_point_exists? method

### DIFF
--- a/lib/gems/pending/appliance_console/internal_database_configuration.rb
+++ b/lib/gems/pending/appliance_console/internal_database_configuration.rb
@@ -129,7 +129,7 @@ module ApplianceConsole
     end
 
     def pg_mount_point?
-      LinuxAdmin::LogicalVolume.mount_point_exists?(mount_point)
+      LinuxAdmin::LogicalVolume.mount_point_exists?(mount_point.to_s)
     end
 
     def run_initdb


### PR DESCRIPTION
This method will return a false negative if passed a Pathname object, which is what we are doing currently.

example from an appliance:

```ruby
irb(main):012:0> LinuxAdmin::LogicalVolume.mount_point_exists?(Pathname.new(ENV.fetch("APPLIANCE_PG_MOUNT_POINT")))
=> false
irb(main):013:0> LinuxAdmin::LogicalVolume.mount_point_exists?(Pathname.new(ENV.fetch("APPLIANCE_PG_MOUNT_POINT")).to_s)
=> true
```
Broken as of https://github.com/ManageIQ/manageiq-gems-pending/pull/277

Appliance builds which include this change will fail with the following output from `journalctl -u appliance-initialize`:

```plain
[root@localhost vmdb]# journalctl -u appliance-initialize
-- Logs begin at Mon 2017-10-16 08:53:57 EDT, end at Mon 2017-10-16 13:01:07 EDT. --
Oct 16 12:54:06 localhost.localdomain systemd[1]: Starting Initialize Appliance Database...
Oct 16 12:54:08 localhost.localdomain appliance-initialize.sh[1305]: TERM environment variable not set.
Oct 16 12:54:08 localhost.localdomain appliance-initialize.sh[1305]: create encryption key
Oct 16 12:54:08 localhost.localdomain appliance-initialize.sh[1305]: configuring internal database
Oct 16 12:54:08 localhost.localdomain appliance-initialize.sh[1305]: The disk for database must be a mount point
Oct 16 12:54:08 localhost.localdomain appliance-initialize.sh[1305]: Failed to configure internal database
Oct 16 12:54:08 localhost.localdomain systemctl[1576]: Removed symlink /etc/systemd/system/multi-user.target.wants/appliance-initialize.service.
Oct 16 12:54:08 localhost.localdomain systemd[1]: Started Initialize Appliance Database.
```

/cc @ailisp 