### PR TITLE
Use pg_basebackup for database backups

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -146,38 +146,6 @@ class PostgresAdmin
   end
 
   def self.restore_pg_compress(opts)
-    # -1
-    # --single-transaction: Execute the restore as a single transaction (that is, wrap the
-    #   emitted commands in BEGIN/COMMIT). This ensures that either all the commands complete
-    #   successfully, or no changes are applied. This option implies --exit-on-error.
-    # -c
-    # --clean
-    #   Clean (drop) database objects before recreating them.
-    # -C
-    # --create
-    #   Create the database before restoring into it. (When this option is used, the database
-    #   named with -d is used only to issue the initial CREATE DATABASE command. All data
-    #   is restored into the database name that appears in the archive.)
-    # -e
-    # --exit-on-error
-    #   Exit if an error is encountered while sending SQL commands to the database. The default is to continue and to display a count of errors at the end of the restoration.
-    # -O
-    # --no-owner
-    #   Do not output commands to set ownership of objects to match the original database.
-    #   By default, pg_restore issues ALTER OWNER or SET SESSION AUTHORIZATION statements to
-    #   set ownership of created schema elements. These statements will fail unless the initial
-    #   connection to the database is made by a superuser (or the same user that owns all of the
-    #   objects in the script). With -O, any user name can be used for the initial connection,
-    #   and this user will own all the created objects.
-    # -a
-    # --data-only
-    #   Restore only the data, not the schema (data definitions).
-    # -U root -h localhost -p 5432
-
-    # `psql -d #{opts[:dbname]} -c "DROP DATABASE #{opts[:dbname]}; CREATE DATABASE #{opts[:dbname]} WITH OWNER = root ENCODING = 'UTF8';"`
-
-    # TODO: In order to restore, we need to drop the database if it exists, and recreate it it blank
-    # An alternative is to use the -a option to only restore the data if there is not a migration/schema change
     unload_pglogical_extension(opts)
     recreate_db(opts)
 

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "binary_struct",           "~> 2.1"
   s.add_runtime_dependency "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
   s.add_runtime_dependency "linux_admin",             "~> 1.0"
+  s.add_runtime_dependency "minitar",                 "~> 0.6"
   s.add_runtime_dependency "more_core_extensions",    "~> 3.4"
   s.add_runtime_dependency "net-scp",                 "~> 1.2.1"
   s.add_runtime_dependency "net-sftp",                "~> 2.1.2"

--- a/spec/util/postgres_admin_spec.rb
+++ b/spec/util/postgres_admin_spec.rb
@@ -97,11 +97,4 @@ describe PostgresAdmin do
       end
     end
   end
-
-  describe ".before_restore" do
-    it "doesn't raise if runcmd does" do
-      expect(described_class).to receive(:runcmd).and_raise(AwesomeSpawn::CommandResultError.new("", ""))
-      expect { described_class.before_restore({}) }.to_not raise_error
-    end
-  end
 end


### PR DESCRIPTION
This PR changes the tool we use for database backups from pg_dump to pg_basebackup

This allows for a more comprehensive backup which includes all databases in the cluster as well as the current state of postgresql config files.

For restore we want to continue to support restoring databases which were backed-up using pg_dump so I added file type detection to switch between which restore method we use.

For pg_basebackup-created files we stop the database, replace the contents of the data directory with the contents of the archive, fix up permissions, and start the database back up.

pg_dump based restore remains unchanged

https://bugzilla.redhat.com/show_bug.cgi?id=1495192