### PR TITLE
[GAPRINDASHVILI] We support 2.3.1 on gaprindashvili appliances

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,6 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 2.2.6
   - 2.3.1
-  - 2.4.2
 before_install: gem install bundler -v 1.12.5
 after_script: bundle exec codeclimate-test-reporter


### PR DESCRIPTION
2.4.x was tested on master and is no longer tested on the gaprindashvili