### PR TITLE
Use $log if it's available, otherwise write to $stderr

### DIFF
--- a/lib/gems/pending/util/extensions/miq-benchmark.rb
+++ b/lib/gems/pending/util/extensions/miq-benchmark.rb
@@ -36,7 +36,7 @@ module Benchmark
           return ret, hash
         rescue Exception
           # Don't let timings be lost on exception when there is nobody else to pick them up.
-          Logger.new($stderr).info("Exception in realtime_block #{key.inspect} - Timings: #{hash.inspect}")
+          logger.info("Exception in realtime_block #{key.inspect} - Timings: #{hash.inspect}")
           raise
         ensure
           delete_current_realtime
@@ -70,6 +70,13 @@ module Benchmark
 
   def self.delete_current_realtime
     @@realtime_by_tid.delete(thread_unique_identifier)
+  end
+
+  private_class_method def self.logger
+    @logger ||= begin
+      require 'logger'
+      $log || Logger.new($stderr)
+    end
   end
 
   @@realtime_by_tid = {}

--- a/spec/util/extensions/miq-benchmark_spec.rb
+++ b/spec/util/extensions/miq-benchmark_spec.rb
@@ -65,6 +65,7 @@ describe Benchmark do
   end
 
   it '.realtime_block with an Exception aborting outermost block' do
+    expect(Benchmark.send(:logger)).to receive(:info).with(/Exception in realtime_block :test1 - Timings: {:test2=>5\.\d*, :test1=>7\.\d*}/)
     expect do
       Benchmark.realtime_block(:test1) do
         Timecop.travel(2.1)
@@ -74,7 +75,6 @@ describe Benchmark do
         end
       end
     end.to raise_exception(Exception)
-      .and output(/Exception in realtime_block :test1 - Timings: {:test2=>5\.\d*, :test1=>7\.\d*}/).to_stderr
 
     expect(Benchmark.in_realtime_block?).to be_falsey
   end


### PR DESCRIPTION
Always writing to $stderr is creating a lot of noise in tests, especially automate tests