### PR TITLE
[FINE] Fog update to 0.1.22

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "excon",                   "~>0.40"
   s.add_runtime_dependency "ffi",                     "~>1.9.3"
   s.add_runtime_dependency "ffi-vix_disk_lib",        "~>1.0.3"  # used by lib/VixDiskLib
-  s.add_runtime_dependency "fog-openstack",           "=0.1.20"
+  s.add_runtime_dependency "fog-openstack",           "=0.1.22"
   s.add_runtime_dependency "hawkular-client",         "=3.0.1"
   s.add_runtime_dependency "highline",                "~> 1.6.21" # Needed for the appliance_console
   s.add_runtime_dependency "httpclient",              "~>2.7.1"


### PR DESCRIPTION
Backport of https://github.com/ManageIQ/manageiq-providers-openstack/pull/129

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1511548