### PR TITLE
[GAPRINDASHVILI][POC] Store unique set size (USS) in the PSS column

### DIFF
--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -110,7 +110,7 @@ class MiqProcess
       cpu_total /= MiqSystem.num_cpus
       percent_cpu             = (1.0 * result[:cpu_time]) / cpu_total
       result[:percent_cpu]    = round_to(percent_cpu * 100.0, 2)
-      result[:proportional_set_size] = Sys::ProcTable.ps(pid).smaps.pss
+      result[:proportional_set_size] = Sys::ProcTable.ps(pid).smaps.uss
     when :macosx
       h = nil
       begin


### PR DESCRIPTION
https://bugzilla.redhat.com/show_bug.cgi?id=1479356

Unique set size is a better way to detect workers that are growing
unbounded since any memory/reference leaks would be shown in their
uss.  If the server process is large when forking, new workers would
inherit a big pss immediately.

We should really rename the column/hash key to uss.

Related PRs:
[master](https://github.com/ManageIQ/manageiq-gems-pending/pull/312)
[gaprindashvili](https://github.com/ManageIQ/manageiq-gems-pending/pull/314)
[fine](https://github.com/ManageIQ/manageiq-gems-pending/pull/313)
[euwe](https://github.com/ManageIQ/manageiq/pull/16480)
