### PR TITLE
[FINE] Don't use Ruby Safe Navigation Operation in Fine Branch

### DIFF
--- a/lib/gems/pending/metadata/util/win32/Win32Software.rb
+++ b/lib/gems/pending/metadata/util/win32/Win32Software.rb
@@ -135,15 +135,17 @@ module MiqWin32
 
       # Get the patches (Win2000, Win2003, WinXP)
       reg_node = MIQRexml.findRegElement("HKEY_LOCAL_MACHINE\\SOFTWARE\\Microsoft\\Windows NT\\CurrentVersion\\Hotfix", reg_doc.root)
-      reg_node&.each_element_with_attribute(:keyname) do |e|
-        attrs = XmlFind.decode(e, HOTFIX_MAPPING)
+      if reg_node
+        reg_node.each_element_with_attribute(:keyname) do |e|
+          attrs = XmlFind.decode(e, HOTFIX_MAPPING)
 
-        # Check both descriptions and take the first one with a value
-        attrs.delete(:description2) if attrs[:description] || attrs[:description2].blank?
-        attrs[:description] = attrs.delete(:description2) if attrs[:description2]
+          # Check both descriptions and take the first one with a value
+          attrs.delete(:description2) if attrs[:description] || attrs[:description2].blank?
+          attrs[:description] = attrs.delete(:description2) if attrs[:description2]
 
-        attrs.merge!(:name => e.attributes[:keyname], :vendor => "Microsoft Corporation", :installed_on => @patch_install_dates[e.attributes[:keyname]]) unless e.attributes.nil? || e.attributes[:keyname].nil?
-        @patches << attrs
+          attrs.merge!(:name => e.attributes[:keyname], :vendor => "Microsoft Corporation", :installed_on => @patch_install_dates[e.attributes[:keyname]]) unless e.attributes.nil? || e.attributes[:keyname].nil?
+          @patches << attrs
+        end
       end
 
       # Get the patches (Vista, Win2008, Windows 7)


### PR DESCRIPTION
https://github.com/ManageIQ/manageiq-smartstate/pull/45 added the use
of the Safe Navigation operator "&." at the urging of CodeClimate.
When this was backported to Fine in manageiq-gems-pending Travis ran it against
Ruby 2.2.6 which does not support the operator so we are removing its usage
here.

The above PR (and this one) fixes the issue found by this BZ - https://bugzilla.redhat.com/show_bug.cgi?id=1490488.

@roliveri @Fryguy please review and merge.  Thanks.