### PR TITLE
 Get the unique_set_size with other process info

### DIFF
--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -98,20 +98,20 @@ class MiqProcess
       wmi.release
     when :linux
       x = MiqProcess.linux_process_stat(pid)
-      result[:name]           = x[:name]
-      result[:priority]       = x[:priority]
-      result[:memory_usage]   = x[:rss] * 4096
-      result[:memory_size]    = x[:vsize]
-      percent_memory          = (1.0 * result[:memory_usage]) / MiqSystem.total_memory
-      result[:percent_memory] = round_to(percent_memory * 100.0, 2)
-      result[:cpu_time]       = x[:stime] + x[:utime]
-      cpu_status              = MiqSystem.status[:cpu]
-      cpu_total               = (0..3).inject(0) { |sum, x| sum + cpu_status[x].to_i }
-      cpu_total /= MiqSystem.num_cpus
-      percent_cpu             = (1.0 * result[:cpu_time]) / cpu_total
-      result[:percent_cpu]    = round_to(percent_cpu * 100.0, 2)
+      result[:name]                  = x[:name]
+      result[:priority]              = x[:priority]
+      result[:memory_usage]          = x[:rss] * 4096
+      result[:memory_size]           = x[:vsize]
+      percent_memory                 = (1.0 * result[:memory_usage]) / MiqSystem.total_memory
+      result[:percent_memory]        = round_to(percent_memory * 100.0, 2)
+      result[:cpu_time]              = x[:stime] + x[:utime]
+      cpu_status                     = MiqSystem.status[:cpu]
+      cpu_total                      = (0..3).inject(0) { |sum, x| sum + cpu_status[x].to_i }
+      cpu_total                     /= MiqSystem.num_cpus
+      percent_cpu                    = (1.0 * result[:cpu_time]) / cpu_total
+      result[:percent_cpu]           = round_to(percent_cpu * 100.0, 2)
       result[:proportional_set_size] = Sys::ProcTable.ps(pid).smaps.pss
-      result[:unique_set_size] = Sys::ProcTable.ps(pid).smaps.uss
+      result[:unique_set_size]       = Sys::ProcTable.ps(pid).smaps.uss
     when :macosx
       h = nil
       begin

--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -110,8 +110,10 @@ class MiqProcess
       cpu_total                     /= MiqSystem.num_cpus
       percent_cpu                    = (1.0 * result[:cpu_time]) / cpu_total
       result[:percent_cpu]           = round_to(percent_cpu * 100.0, 2)
-      result[:proportional_set_size] = Sys::ProcTable.ps(pid).smaps.pss
-      result[:unique_set_size]       = Sys::ProcTable.ps(pid).smaps.uss
+
+      smaps = Sys::ProcTable.ps(pid).smaps
+      result[:proportional_set_size] = smaps.pss
+      result[:unique_set_size]       = smaps.uss
     when :macosx
       h = nil
       begin

--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -111,6 +111,7 @@ class MiqProcess
       percent_cpu             = (1.0 * result[:cpu_time]) / cpu_total
       result[:percent_cpu]    = round_to(percent_cpu * 100.0, 2)
       result[:proportional_set_size] = Sys::ProcTable.ps(pid).smaps.pss
+      result[:unique_set_size] = Sys::ProcTable.ps(pid).smaps.uss
     when :macosx
       h = nil
       begin


### PR DESCRIPTION
Why?  USS is a more reliable mechanism for tracking workers with runaway
memory growth.  PSS is great, until the server process that forks new
processes grows large. As each new worker is forked, it inherits a share
of the large amount of the parent process' memory and therefore starts
with a large PSS, possibly exceeding our limits before doing any work.
USS only measures a process' private memory and is a better indicator
when a process is responsible for allocating too much memory without
freeing it.

This is needed for PR: ManageIQ/manageiq#16569