### PR TITLE
Add valid_encoding checking before inserting into xml object.

### DIFF
--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -148,7 +148,7 @@ module REXML
         rescue => err
           if err.class == ::Encoding::CompatibilityError
             second_utf8 = second.to_s.force_encoding('UTF-8')
-            @value = Text.unnormalize(second_utf8, nil)
+            @value = Text.unnormalize(second_utf8.valid_encoding? ? second_utf8 : "Invalid encoding found", nil)
           else
             $log.error "Encoding error: #{second_utf8}" if $log
           end
@@ -223,7 +223,7 @@ module REXML
     def add_element(element, attrs = nil)
       return add_element_orig(element) if element.kind_of?(REXML::Element)
       attrs.delete_if { |_k, v| v.nil? } unless attrs.nil?
-      add_element_orig(element.to_s, XmlHelpers.stringify_keys(attrs))
+      add_element_orig(element.to_s, XmlHelpers.validate_attrs(attrs))
     end
 
     alias_method :add_attribute_orig, :add_attribute

--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -147,8 +147,8 @@ module REXML
           @value = Text.unnormalize(second.to_s, nil)
         rescue => err
           if err.class == ::Encoding::CompatibilityError
-            second_utf8 = second.to_s.force_encoding('UTF-8')
-            @value = Text.unnormalize(second_utf8.valid_encoding? ? second_utf8 : "Invalid encoding found", nil)
+            second_utf8 = second.to_s.force_encoding('UTF-8').encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '')
+            @value = Text.unnormalize(second_utf8)
           else
             $log.error "Encoding error: #{second_utf8}" if $log
           end

--- a/lib/gems/pending/util/xml/xml_utils.rb
+++ b/lib/gems/pending/util/xml/xml_utils.rb
@@ -62,18 +62,10 @@ class XmlFind
 end
 
 class XmlHelpers
-  # reference from REXML::TEXT
-  VALID_CHAR = [
-    0x9, 0xA, 0xD,
-    (0x20..0xD7FF),
-    (0xE000..0xFFFD),
-    (0x10000..0x10FFFF)
-  ]
-
   def self.remove_invalid_chars(str)
     str.chars.reject do |c|
       case c.ord
-      when *VALID_CHAR
+      when *REXML::Text::VALID_CHAR
       else
         ''
       end
@@ -93,6 +85,7 @@ class XmlHelpers
 end
 
 class Xml2tags
+
   def self.walk(node, parents = "")
     tags = []
 

--- a/lib/gems/pending/util/xml/xml_utils.rb
+++ b/lib/gems/pending/util/xml/xml_utils.rb
@@ -62,10 +62,28 @@ class XmlFind
 end
 
 class XmlHelpers
+  # reference from REXML::TEXT
+  VALID_CHAR = [
+    0x9, 0xA, 0xD,
+    (0x20..0xD7FF),
+    (0xE000..0xFFFD),
+    (0x10000..0x10FFFF)
+  ]
+
+  def self.remove_invalid_chars(str)
+    str.chars.reject do |c|
+      case c.ord
+      when *VALID_CHAR
+      else
+        ''
+      end
+    end.join
+  end
+
   # Validate attributes before inserting into xml
   def self.validate_attrs(h)
     return nil if h.nil?
-    h.inject({}) { |options, (key, value)| options[key.to_s] = value.to_s.force_encoding('UTF-8').valid_encoding? ? value : "Invalid encoding found"; options }
+    h.each_with_object({}) { |(k, v), h| h[k.to_s] = remove_invalid_chars(v.to_s.encode('UTF-8', :undef => :replace, :invalid => :replace, :replace => '')) }
   end
 
   def self.stringify_keys(h)

--- a/lib/gems/pending/util/xml/xml_utils.rb
+++ b/lib/gems/pending/util/xml/xml_utils.rb
@@ -62,6 +62,12 @@ class XmlFind
 end
 
 class XmlHelpers
+  # Validate attributes before inserting into xml
+  def self.validate_attrs(h)
+    return nil if h.nil?
+    h.inject({}) { |options, (key, value)| options[key.to_s] = value.to_s.force_encoding('UTF-8').valid_encoding? ? value : "Invalid encoding found"; options }
+  end
+
   def self.stringify_keys(h)
     return nil if h.nil?
     h.inject({}) { |options, (key, value)| options[key.to_s] = value; options }

--- a/spec/util/xml/miq_rexml_spec.rb
+++ b/spec/util/xml/miq_rexml_spec.rb
@@ -27,4 +27,11 @@ describe MIQRexml do
     xml = MiqXml.load(doc_text)
     expect(xml.root.elements[1].attributes['attr1']).to eq(attr_string)
   end
+
+  it "add_element with control characters" do
+    attr_hash = { "attr1" => "test\u000Fst\u001Fring" }
+    doc = MiqXml.createDoc(nil)
+    doc.add_element('element_1', attr_hash)
+    expect(doc.elements[1].attributes['attr1']).to eq("teststring")
+  end
 end


### PR DESCRIPTION
Some special control characters, here '\u000F' and '\u001F', are valid chars in UTF-8 encoding, but unacceptable when we try to convert them into XML. A check is added to remove them first before xml conversion.

https://bugzilla.redhat.com/show_bug.cgi?id=1518249