### PR TITLE
Always use SSH in non-interactive mode

### DIFF
--- a/lib/gems/pending/util/MiqSshUtil.rb
+++ b/lib/gems/pending/util/MiqSshUtil.rb
@@ -9,7 +9,12 @@ class MiqSshUtil
     @password = password
     @status   = 0
     @shell    = nil
-    @options  = {:password => @password, :remember_host => false, :verbose => :warn}.merge(options)
+    @options  = {
+      :password        => @password,
+      :remember_host   => false,
+      :verbose         => :warn,
+      :non_interactive => true,
+    }.merge(options)
 
     # Seems like in 2.9.2, there needs to be blank :keys, when we are passing private key as string
     @options[:keys] = [] if options[:key_data]


### PR DESCRIPTION
The default configuration of the `net/ssh` gem uses _interactive_ mode.
That means that when authentication with a provided password fails, the
gem will retry, discarding the provided password and asking
interactively for a new one. In the ManageIQ environment this will
always fail, because there is no human user to type that alternative
password. The result is the following error:

  Errno::ENOTTY: Inappropriate ioctl for device

That happens when the gem tries to read the password using the
`IO#noecho` method, because inside the ManageIQ process `$stdin` isn't
attached to a terminal.

The net result is an exception that isn't caught by the gem, and scary
error messages in the log and in the UI.

To avoid these problems this patch adds the `:non_interactive => true`
option to the constructor of the SSH client. This instructs the gem to
never retry failed authentications interactively.

This addresses the following bug:

  Password change for a Host fails with error code 500
  https://bugzilla.redhat.com/1516849
