### PR TITLE
Fix require net/sftp for Users SSA

### DIFF
--- a/lib/gems/pending/util/MiqSshUtil.rb
+++ b/lib/gems/pending/util/MiqSshUtil.rb
@@ -1,4 +1,5 @@
 require 'net/ssh'
+require 'net/sftp'
 
 class MiqSshUtil
   attr_reader :status, :host


### PR DESCRIPTION
Fixing bug when users synchronization failed during SSA because of failure
in MiqSshUtil caused by uninitialized constant Net::SFTP.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1529127