### PR TITLE
[WIP] Load linux_admin once when needed

### DIFF
--- a/lib/gems/pending/util/miq-system.rb
+++ b/lib/gems/pending/util/miq-system.rb
@@ -47,7 +47,7 @@ class MiqSystem
 
   def self.num_cpus
     return unless Sys::Platform::IMPL == :linux
-    require 'linux_admin'
+    require_linux_admin
     @num_cpus ||= LinuxAdmin::Hardware.new.total_cores
   end
 
@@ -227,6 +227,12 @@ class MiqSystem
     when :linux         then `xdg-open #{url.shellescape}`
     when :mingw, :mswin then `start "#{url.gsub('"', '""')}"`
     end
+  end
+
+  def self.require_linux_admin
+    return true if @linux_admin_required
+    require "linux_admin"
+    @linux_admin_required = true
   end
 end
 


### PR DESCRIPTION
Due to some concerns about loading `linux_admin` multiple times when calling `MiqSystem.num_cpus` causing a memory leak, this creates a helper method that no-ops after it has been required once.

This is currently a [WIP] pull request as we verify further that calling `require` multiple times is leaking memory in the `manageiq` application, but putting this out there as a proposal for a quick fix.  Fixing require to not leak is far more ideal, but will take time.

Concerns
--------

Unsure if this will break autoloading in some way, though I doubt too many are trying to do a reload with in development `linux_admin`, or calling code where this would be executed and reloaded in development.  Regardless, something to consider when reviewing.