### PR TITLE
Create an empty directory for pg_basebackup

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -163,8 +163,10 @@ class PostgresAdmin
 
     path = Pathname.new(opts.delete(:local_file))
 
-    runcmd("pg_basebackup", opts, :z => nil, :format => "t", :xlog_method => "fetch", :pgdata => path.dirname)
-    FileUtils.mv(path.dirname.join("base.tar.gz"), path)
+    Dir.mktmpdir("vmdb_backup", path.dirname) do |dir|
+      runcmd("pg_basebackup", opts, :z => nil, :format => "t", :xlog_method => "fetch", :pgdata => dir)
+      FileUtils.mv(File.join(dir, "base.tar.gz"), path)
+    end
     path.to_s
   end
 


### PR DESCRIPTION
This is needed for the `--pgdata` option.
Previously we were trying to use the directory of the path given
for the backup file name. This was failing because there is no
guarentee that the directory given is empty.

This commit creates a temp directory in the parent directory of
the given file. This ensures that we are writing the backup on the
same volume that the user intends the backup to be stored on so we are
much more likely to have space to write.

https://bugzilla.redhat.com/show_bug.cgi?id=1538584