### PR TITLE
Fix ENOENT error from backup_pg_compress

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -163,6 +163,7 @@ class PostgresAdmin
 
     path = Pathname.new(opts.delete(:local_file))
 
+    FileUtils.mkdir_p(path.dirname)
     Dir.mktmpdir("vmdb_backup", path.dirname) do |dir|
       runcmd("pg_basebackup", opts, :z => nil, :format => "t", :xlog_method => "fetch", :pgdata => dir)
       FileUtils.mv(File.join(dir, "base.tar.gz"), path)


### PR DESCRIPTION
Dir.mktmpdir fails if the base directory doesn't exist with ENOENT so
first make sure that the base path exists.

https://travis-ci.org/ManageIQ/manageiq/jobs/333519975#L1334-L1350

```
Failures:
  1) EvmDatabaseOps#backup remotely without a remote file name
     Failure/Error: backup = PostgresAdmin.backup(db_opts)
     Errno::ENOENT:
       No such file or directory @ dir_s_mkdir - /home/travis/build/ManageIQ/manageiq/tmp/db_backup/vmdb_backup20180125-7288-cziha5
     # ./lib/evm_database_ops.rb:64:in `backup'
     # ./spec/lib/evm_database_ops_spec.rb:45:in `block (3 levels) in <top (required)>'
  2) EvmDatabaseOps#backup remotely
     Failure/Error: backup = PostgresAdmin.backup(db_opts)
     Errno::ENOENT:
       No such file or directory @ dir_s_mkdir - /home/travis/build/ManageIQ/manageiq/tmp/db_backup/vmdb_backup20180125-7288-1wok2su
     # ./lib/evm_database_ops.rb:64:in `backup'
```