### PR TITLE
[FINE] Remove Safe Navigation Operator

### DIFF
--- a/lib/gems/pending/disk/modules/AzureDiskCommon.rb
+++ b/lib/gems/pending/disk/modules/AzureDiskCommon.rb
@@ -43,7 +43,7 @@ module AzureDiskCommon
   end
 
   def d_close_common
-    @managed_disk&.close
+    @managed_disk.close if @managed_disk
     return nil unless $log.debug?
     t1 = Time.now.to_i
     $log.debug("#{@my_class}: close(#{@disk_path})")


### PR DESCRIPTION
The previous fix for the Managed Disk semantics change used a
Safe Navigation operator "&." which is not supported in the older
version of ruby still being used to build the manageiq-gems-pending repo.

@roliveri @hsong-rh please review.  This is required for the backport of https://github.com/ManageIQ/manageiq-smartstate/pull/50.