### PR TITLE
Fixed to validate attributes before inserting into XML.

### DIFF
--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -228,7 +228,8 @@ module REXML
 
     alias_method :add_attribute_orig, :add_attribute
     def add_attribute(key, value)
-      add_attribute_orig(key.to_s, value.to_s) unless value.nil?
+      value_utf8 = value.to_s.force_encoding('UTF-8').encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '') unless value.nil?
+      add_attribute_orig(key.to_s, value_utf8) unless value_utf8.nil?
     end
 
     alias_method :add_attributes_orig, :add_attributes


### PR DESCRIPTION
Filter out the unrecognized characters in attributes before inserting into XML.

https://bugzilla.redhat.com/show_bug.cgi?id=1533843