### PR TITLE
Update ruby travis support (drop 2.2, test 2.3.6)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 2.2.6
   - 2.3.1
   - 2.4.2
 before_install: gem install bundler -v 1.12.5

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
-  - 2.3.1
+  - 2.3.6
   - 2.4.2
 before_install: gem install bundler -v 1.12.5
 after_script: bundle exec codeclimate-test-reporter


### PR DESCRIPTION
* Don't test on ruby 2.2
We dropped support for ruby 2.2 on master months ago:
http://talk.manageiq.org/t/adding-support-for-ruby-2-4-and-dropping-2-2/2305

* test with ruby 2.3.6 (what's used on appliances)