### PR TITLE
[FINE] Safe Navigation Operator Isn't Safe in Fine Branch

### DIFF
--- a/lib/gems/pending/VolumeManager/LVM/scanner.rb
+++ b/lib/gems/pending/VolumeManager/LVM/scanner.rb
@@ -101,7 +101,7 @@ module Lvm2Scanner
   def self.readLabel(d, s)
     d.seek(s * SECTOR_SIZE, IO::SEEK_SET)
     lh = readStruct(d, LABEL_HEADER)
-    return lh if lh&.lvm_id == LVM_ID
+    return lh if lh && lh.lvm_id == LVM_ID
     nil
   end # def self.readLabel
 
@@ -163,7 +163,7 @@ module Lvm2Scanner
   def self.readStruct(d, struct)
     OpenStruct.new(struct.decode(d.read(struct.size)))
   rescue StandardError => err
-    $log&.debug err.to_s
+    $log.debug err.to_s if $log
     nil
   end # def self.readStruct
 end # module Lvm2Scanner

--- a/lib/gems/pending/fs/MiqFS/modules/AUFSProbe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/AUFSProbe.rb
@@ -15,7 +15,7 @@ module AUFSProbe
     # Check for aufs magic number or name at offset.
     dobj.seek(AUFS_SUPER_OFFSET + AUFS_MAGIC_OFFSET)
     buf = dobj.read(AUFS_MAGIC_SIZE)
-    bs = buf&.unpack('L')
+    bs  = buf.unpack('L') if buf
     magic = bs.nil? ? nil : bs[0]
 
     raise "AUFS is Not Supported" if magic == AUFS_SUPER_MAGIC || buf == AUFS_FSTYPE

--- a/lib/gems/pending/fs/MiqFS/modules/Ext3Probe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/Ext3Probe.rb
@@ -3,7 +3,7 @@ require 'fs/ext3/superblock'
 module Ext3Probe
   def self.probe(dobj)
     unless dobj.kind_of?(MiqDisk)
-      $log&.debug("Ext3Probe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'")
+      $log.debug("Ext3Probe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'") if $log
       return false
     end
 
@@ -11,10 +11,10 @@ module Ext3Probe
     Ext3::Superblock.new(dobj)
 
     # If initializing the superblock does not throw any errors, then this is ext3
-    $log&.debug("Ext3Probe << TRUE")
+    $log.debug("Ext3Probe << TRUE") if $log
     return true
   rescue => err
-    $log&.debug("Ext3Probe << FALSE because #{err.message}")
+    $log.debug("Ext3Probe << FALSE because #{err.message}") if $log
     return false
   ensure
     dobj.seek(0, IO::SEEK_SET)

--- a/lib/gems/pending/fs/MiqFS/modules/Ext4Probe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/Ext4Probe.rb
@@ -3,7 +3,7 @@ require 'fs/ext4/superblock'
 module Ext4Probe
   def self.probe(dobj)
     unless dobj.kind_of?(MiqDisk)
-      $log&.debug("Ext4Probe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'")
+      $log.debug("Ext4Probe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'") if $log
       return false
     end
 
@@ -11,10 +11,10 @@ module Ext4Probe
     Ext4::Superblock.new(dobj)
 
     # If initializing the superblock does not throw any errors, then this is Ext4
-    $log&.debug("Ext4Probe << TRUE")
+    $log.debug("Ext4Probe << TRUE") if $log
     return true
   rescue => err
-    $log&.debug("Ext4Probe << FALSE because #{err.message}")
+    $log.debug("Ext4Probe << FALSE because #{err.message}") if $log
     return false
   ensure
     dobj.seek(0, IO::SEEK_SET)

--- a/lib/gems/pending/fs/MiqFS/modules/Fat32Probe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/Fat32Probe.rb
@@ -1,7 +1,7 @@
 module Fat32Probe
   def self.probe(dobj)
     unless dobj.kind_of?(MiqDisk)
-      $log&.debug "Fat32Probe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'"
+      $log.debug "Fat32Probe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'" if $log
       return false
     end
 
@@ -11,14 +11,14 @@ module Fat32Probe
 
     # Check byte 66 for 0x29 (extended signature).
     if bs.nil? || bs[66] != 0x29
-      $log&.debug("Fat32Probe << FALSE because there is no extended signature")
+      $log.debug("Fat32Probe << FALSE because there is no extended signature") if $log
       return false
     end
 
     # Check file system label for 'FAT32   '
     # NOTE: This works for MS tools but maybe not for others.
     if bs.length < 90
-      $log&.debug("Fat32Probe << FALSE because there is no filesystem label")
+      $log.debug("Fat32Probe << FALSE because there is no filesystem label") if $log
       return false
     end
 

--- a/lib/gems/pending/fs/MiqFS/modules/HFSProbe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/HFSProbe.rb
@@ -9,7 +9,8 @@ module HFSProbe
 
     # Check for HFS signature in first int.
     dobj.seek(HFS_SUPER_OFFSET + HFS_MAGIC_OFFSET)
-    bs = dobj.read(HFS_MAGIC_SIZE)&.unpack('S')
+    buf = dobj.read(HFS_MAGIC_SIZE)
+    bs = buf.unpack('S') if buf
     magic = bs.nil? ? nil : bs[0]
     raise "HFS is Not Supported" if magic == HFS_SUPER_MAGIC
 

--- a/lib/gems/pending/fs/MiqFS/modules/NTFSProbe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/NTFSProbe.rb
@@ -1,13 +1,14 @@
 module NTFSProbe
   def self.probe(dobj)
     unless dobj.kind_of?(MiqDisk)
-      $log&.debug "NTFSProbe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'"
+      $log.debug "NTFSProbe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'" if $log
       return false
     end
 
     # Check for oem name = NTFS.
     dobj.seek(3)
-    bs = dobj.read(8)&.unpack('a8')
+    buf = dobj.read(8)
+    bs  = buf.unpack('a8') if buf
     oem = bs[0].strip if bs
 
     ntfs = oem == 'NTFS'

--- a/lib/gems/pending/fs/MiqFS/modules/ReFSProbe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/ReFSProbe.rb
@@ -5,7 +5,8 @@ module ReFSProbe
     return false unless dobj.kind_of?(MiqDisk)
 
     dobj.seek(0, IO::SEEK_SET)
-    magic = dobj.read(FS_SIGNATURE.size)&.unpack('C*')
+    buf   = dobj.read(FS_SIGNATURE.size)
+    magic = buf.unpack('C*') if buf
 
     # Check for ReFS signature
     raise "ReFS is Not Supported" if magic == FS_SIGNATURE

--- a/lib/gems/pending/fs/MiqFS/modules/Reiser4Probe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/Reiser4Probe.rb
@@ -9,7 +9,8 @@ module Reiser4Probe
 
     # Assume Reiser4 - read magic at offset.
     dobj.seek(REISER4_MAGIC_OFFSET)
-    magic = dobj.read(REISER4_MAGIC_SIZE)&.strip
+    buf   = dobj.read(REISER4_MAGIC_SIZE)
+    magic = buf.strip if buf
     raise "Reiser4 is Not Supported" if magic == REISER4_MAGIC
 
     # No Reiser4.

--- a/lib/gems/pending/fs/MiqFS/modules/UnionFSProbe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/UnionFSProbe.rb
@@ -9,7 +9,8 @@ module UnionFSProbe
 
     # Assume UnionFS - read magic at offset.
     dobj.seek(UNIONFS_SUPER_OFFSET + UNIONFS_MAGIC_OFFSET)
-    magic = dobj.read(UNIONFS_MAGIC_SIZE)&.unpack('L')
+    buf   = dobj.read(UNIONFS_MAGIC_SIZE)
+    magic = buf.unpack('L') if buf
     raise "UnionFS is Not Supported" if magic == UNIONFS_MAGIC
 
     # No UnionFS.

--- a/lib/gems/pending/fs/MiqFS/modules/XFSProbe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/XFSProbe.rb
@@ -3,7 +3,7 @@ require 'fs/xfs/superblock'
 module XFSProbe
   def self.probe(dobj)
     unless dobj.kind_of?(MiqDisk)
-      $log&.debug("XFSProbe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'")
+      $log.debug("XFSProbe << FALSE because Disk Object class is not MiqDisk, but is '#{dobj.class}'") if $log
       return false
     end
 
@@ -12,10 +12,10 @@ module XFSProbe
     XFS::Superblock.new(dobj)
 
     # If initializing the superblock does not throw any errors, then this is XFS
-    $log&.debug("XFSProbe << TRUE")
+    $log.debug("XFSProbe << TRUE") if $log
     return true
   rescue => err
-    $log&.debug("XFSProbe << FALSE because #{err.message}")
+    $log.debug("XFSProbe << FALSE because #{err.message}") if $log
     return false
   ensure
     dobj.seek(0, IO::SEEK_SET)

--- a/lib/gems/pending/fs/MiqFS/modules/ZFSProbe.rb
+++ b/lib/gems/pending/fs/MiqFS/modules/ZFSProbe.rb
@@ -9,7 +9,8 @@ module ZFSProbe
 
     # Check for magic at uberblock offset.
     dobj.seek(ZFS_SUPER_OFFSET + ZFS_MAGIC_OFFSET)
-    bs = dobj.read(ZFS_MAGIC_SIZE)&.unpack('L')
+    buf = dobj.read(ZFS_MAGIC_SIZE)
+    bs  = buf.unpack('L') if buf
     magic = bs.nil? ? nil : bs[0]
     raise "ZFS is Not Supported" if magic == ZFS_SUPER_MAGIC
 


### PR DESCRIPTION
Don't use the Safe Navigation Operator when building against ruby 2.2.

@hsong-rh @roliveri please review. 

Fixes an issue caused by the fix for https://bugzilla.redhat.com/show_bug.cgi?id=1565362 in this commit https://github.com/ManageIQ/manageiq-gems-pending/commit/5bf2750534f8bbe82375b100fc341f1212dd507c