### PR TITLE
Remove references to RAILS_ROOT

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -2,8 +2,6 @@ require 'awesome_spawn'
 require 'pathname'
 require 'linux_admin'
 
-RAILS_ROOT ||= Pathname.new(__dir__).join("../../../")
-
 class PostgresAdmin
   def self.data_directory
     Pathname.new(ENV.fetch("APPLIANCE_PG_DATA"))
@@ -28,10 +26,6 @@ class PostgresAdmin
   # Unprivileged user to run postgresql
   def self.user
     "postgres".freeze
-  end
-
-  def self.certificate_location
-    RAILS_ROOT.join("certs")
   end
 
   def self.logical_volume_name

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -10,11 +10,6 @@ $log ||= Logger.new("/dev/null")
 # $log ||= Logger.new(STDOUT)
 # $log.level = Logger::DEBUG
 
-# For Appliance console logging tests
-require 'tmpdir'
-RAILS_ROOT = Pathname.new(Dir.mktmpdir("manageiq-gems-pending"))
-Dir.mkdir(RAILS_ROOT.join("log"))
-
 # Requires supporting files with custom matchers and macros, etc,
 # in ./support/ and its subdirectories.
 Dir[File.expand_path(File.join(__dir__, 'support/**/*.rb'))].each { |f| require f }


### PR DESCRIPTION
The last caller of PostgresAdmin.certificate_location was removed in https://github.com/ManageIQ/manageiq-appliance_console/pull/22

Fixes #4