### PR TITLE
Add pg_dump support back to PostgresAdmin

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -226,4 +226,12 @@ class PostgresAdmin
   private_class_method def self.file_type(file)
     AwesomeSpawn.run!("file", :params => {:b => nil, nil => file}).output
   end
+
+  private_class_method def self.combine_command_args(opts, args)
+    default_args            = {:no_password => nil}
+    default_args[:dbname]   = opts[:dbname]   if opts[:dbname]
+    default_args[:username] = opts[:username] if opts[:username]
+    default_args[:host]     = opts[:hostname] if opts[:hostname]
+    default_args.merge(args)
+  end
 end

--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -207,13 +207,7 @@ class PostgresAdmin
   end
 
   def self.runcmd(cmd_str, opts, args)
-    default_args            = {:no_password => nil}
-    default_args[:dbname]   = opts[:dbname]   if opts[:dbname]
-    default_args[:username] = opts[:username] if opts[:username]
-    default_args[:host]     = opts[:hostname] if opts[:hostname]
-    args = default_args.merge(args)
-
-    runcmd_with_logging(cmd_str, opts, args)
+    runcmd_with_logging(cmd_str, opts, combine_command_args(opts, args))
   end
 
   def self.runcmd_with_logging(cmd_str, opts, params = {})

--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -118,6 +118,13 @@ class PostgresAdmin
     file
   end
 
+  def self.backup_pg_dump(opts)
+    opts = opts.dup
+    dbname = opts.delete(:dbname)
+    runcmd("pg_dump", opts, :format => "c", :file => opts[:local_file], nil => dbname)
+    opts[:local_file]
+  end
+
   def self.backup_pg_compress(opts)
     opts = opts.dup
 

--- a/spec/util/postgres_admin_spec.rb
+++ b/spec/util/postgres_admin_spec.rb
@@ -76,6 +76,84 @@ describe PostgresAdmin do
         expect(subject.backup_pg_dump(opts)).to eq(local_file)
       end
     end
+
+    shared_examples "for splitting multi value arg" do |arg_type|
+      arg_as_cmdline_opt = "-#{'-' if arg_type.size > 1}#{arg_type}"
+
+      let(:local_file) { "/some/path/to/pg.dump" }
+
+      context "with #{arg_as_cmdline_opt} as a single value" do
+        let(:expected_opts) { { :local_file => local_file } }
+        let(:expected_args) do
+          default_args.to_a << [arg_type, "value1"]
+        end
+
+        it "runs the command and returns the :local_file opt" do
+          opts = expected_opts.merge(arg_type => "value1")
+          expect(subject.backup_pg_dump(opts)).to eq(local_file)
+        end
+      end
+
+      context "with #{arg_as_cmdline_opt} as a single value array" do
+        let(:expected_opts) { { :local_file => local_file } }
+        let(:expected_args) do
+          default_args.to_a << [arg_type, "value1"]
+        end
+
+        it "runs the command and returns the :local_file opt" do
+          opts = expected_opts.merge(arg_type => ["value1"])
+          expect(subject.backup_pg_dump(opts)).to eq(local_file)
+        end
+      end
+
+      context "with #{arg_as_cmdline_opt} as a multi value array" do
+        let(:expected_opts) { { :local_file => local_file } }
+        let(:expected_args) do
+          default_args.to_a << [arg_type, "value1"] << [arg_type, "value2"]
+        end
+
+        it "runs the command and returns the :local_file opt" do
+          opts = expected_opts.merge(arg_type => %w[value1 value2])
+          expect(subject.backup_pg_dump(opts)).to eq(local_file)
+        end
+      end
+    end
+
+    context "with :local_file, :t in opts" do
+      include_examples "for splitting multi value arg", :t
+    end
+
+    context "with :local_file, :table in opts" do
+      include_examples "for splitting multi value arg", :table
+    end
+
+    context "with :local_file, :T in opts" do
+      include_examples "for splitting multi value arg", :T
+    end
+
+    context "with :local_file, :exclude-table in opts" do
+      include_examples "for splitting multi value arg", :"exclude-table"
+    end
+
+    context "with :local_file, :exclude-table-data in opts" do
+      include_examples "for splitting multi value arg", :"exclude-table-data"
+    end
+
+    context "with :local_file, :t in opts" do
+      include_examples "for splitting multi value arg", :n
+    end
+
+    context "with :local_file, :table in opts" do
+      include_examples "for splitting multi value arg", :schema
+    end
+
+    context "with :local_file, :T in opts" do
+      include_examples "for splitting multi value arg", :N
+    end
+
+    context "with :local_file, :exclude-table in opts" do
+      include_examples "for splitting multi value arg", :"exclude-schema"
+    end
   end
 
   context "ENV dependent" do

--- a/spec/util/postgres_admin_spec.rb
+++ b/spec/util/postgres_admin_spec.rb
@@ -17,8 +17,7 @@ describe PostgresAdmin do
     end
 
     before do
-      expect(subject).to receive(:runcmd_with_logging)
-                           .with("pg_dump", expected_opts, expected_args)
+      expect(subject).to receive(:runcmd_with_logging).with("pg_dump", expected_opts, expected_args)
     end
 
     context "with empty args" do


### PR DESCRIPTION
Adds `PostgresAdmin.backup_pg_dump`, which mostly undoes the changes in https://github.com/ManageIQ/manageiq-gems-pending/commit/271febd3 (from https://github.com/ManageIQ/manageiq-gems-pending/pull/302 ).

In addition:

  * Refactors out `PostgresAdmin.combine_command_args`
  * Uses that method in `PostgresAdmin.runcmd`
  * Updates `PostgresAdmin.backup_pg_dump` to use `.combine_command_args` and a new method `.handle_multi_value_pg_dump_args!` to handle arguments for `pg_dump` that can have multiple values, and passes them to `AwesomeSpawn` in a manner that `pg_dump` should be happy with.

The end result is that `.backup_pg_dump` will call to `runcmd_with_logging` directly instead of `runcmd`, but that is just a implementation detail.


Remaining questions
-------------------

* Do we want to make `PostgresAdmin.backup` default to `PostgresAdmin.backup_pg_compress` by default, but if it gets any `-t` or `--table` type args, use `pg_dump` instead? (I am indifferent, but we are kind of doing this already with `restore`, so I figured I would ask)
* Related to the above:  Since this is for [BZ#1535345](https://bugzilla.redhat.com/show_bug.cgi?id=1535345), do we want to add another option to the `appliance_console` to differentiate between `Database Backup` and `Database Dump`?
  - A:  We will be differentiating between "dump"/"backup", as far as I can tell.  I will make sure to add a "WARNING" @carbonin 's suggestion [here](https://github.com/ManageIQ/manageiq-gems-pending/pull/351#pullrequestreview-119083017)


Links
-----

* https://bugzilla.redhat.com/show_bug.cgi?id=1535345