### PR TITLE
S3 db restore

### DIFF
--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -187,14 +187,6 @@ class MiqGenericMountSession
     connect
   end
 
-  def self.supports_objects?
-    false
-  end
-
-  def supports_objects?
-    false
-  end
-
   def with_test_file(&_block)
     raise "requires a block" unless block_given?
     file = '/tmp/miq_verify_test_file'

--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -187,6 +187,14 @@ class MiqGenericMountSession
     connect
   end
 
+  def self.supports_objects?
+    false
+  end
+
+  def supports_objects?
+    false
+  end
+
   def with_test_file(&_block)
     raise "requires a block" unless block_given?
     file = '/tmp/miq_verify_test_file'

--- a/lib/gems/pending/util/mount/miq_s3_session.rb
+++ b/lib/gems/pending/util/mount/miq_s3_session.rb
@@ -84,10 +84,6 @@ class MiqS3Session < MiqGenericMountSession
     local_file
   end
 
-  def supports_objects?
-    true
-  end
-
   private
 
   def s3


### PR DESCRIPTION
Part of the continuing saga of the RFE to allow backups/restores from AWS S3 and Openstack Swift.
This enables downloading the backup file from S3 prior to running the restore command.

Other PRs in this series include 
https://github.com/ManageIQ/manageiq-ui-classic/pull/4300
https://github.com/ManageIQ/manageiq/pull/17689
https://github.com/ManageIQ/manageiq-schema
https://github.com/ManageIQ/manageiq-gems-pending

One of several PRs required for RFE in https://bugzilla.redhat.com/show_bug.cgi?id=1513520
@roliveri @carbonin please review.