### PR TITLE
Fix issue caused by missing source file in add call

### DIFF
--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -258,6 +258,10 @@ class MiqGenericMountSession
         logger.info("#{log_header} Skipping add since URI: [#{dest_uri}] already exists")
         return dest_uri
       end
+      unless File.exist?(source)
+        logger.info("#{log_header} Skipping add since file: [#{source}] does not exist")
+        return source
+      end
 
       logger.info("#{log_header} Building relative path: [#{relpath}]...")
       FileUtils.mkdir_p(File.dirname(relpath))


### PR DESCRIPTION
Changes to EvmDatabaseOps for PR https://github.com/ManageIQ/manageiq/pull/17689
based on review comments in that PR
will require that the session add method be called on all sessions.  This allows
us to fail gracefully and fixes a spec test in THAT PR.

@carbonin and @roliveri  your proverbial can of worms.  Please review and merge this so we can move forward.  Thanks.