### PR TITLE
Remove Debug Messages

### DIFF
--- a/lib/gems/pending/util/mount/miq_s3_session.rb
+++ b/lib/gems/pending/util/mount/miq_s3_session.rb
@@ -2,10 +2,7 @@ require 'util/mount/miq_generic_mount_session'
 
 class MiqS3Session < MiqGenericMountSession
   def initialize(log_settings)
-    log_header = "MIQ(#{self.class.name}-initialize)"
-    logger.debug("#{log_header} initialize: log_settings are #{log_settings}")
     super(log_settings)
-    logger.debug("#{log_header} initialize: @settings are #{@settings}")
     # NOTE: This line to be removed once manageiq-ui-class region change implemented.
     @settings[:region] = "us-east-1" if @settings[:region].nil?
     raise "username, password, and region are required values!" if @settings[:username].nil? || @settings[:password].nil? || @settings[:region].nil?


### PR DESCRIPTION
Two debug log messages were left in this file that result in the username and password
being printed in clear text.  This is obviously incorrect.

@carbonin @roliveri please review and merge.  Thank you.