### PR TITLE
Update PG_DUMP_MULTI_VALUE_ARGS for underscore args

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -235,8 +235,8 @@ class PostgresAdmin
 
   # rubocop:disable Style/SymbolArray
   PG_DUMP_MULTI_VALUE_ARGS = [
-    :t, :table,  :T, :"exclude-table", :"exclude-table-data",
-    :n, :schema, :N, :"exclude-schema"
+    :t, :table,  :T, :exclude_table,  :"exclude-table", :exclude_table_data, :"exclude-table-data",
+    :n, :schema, :N, :exclude_schema, :"exclude-schema"
   ].freeze
   # rubocop:enable Style/SymbolArray
   #

--- a/spec/util/postgres_admin_spec.rb
+++ b/spec/util/postgres_admin_spec.rb
@@ -131,12 +131,20 @@ describe PostgresAdmin do
       include_examples "for splitting multi value arg", :T
     end
 
+    context "with :local_file, :exclude_table in opts" do
+      include_examples "for splitting multi value arg", :exclude_table
+    end
+
     context "with :local_file, :exclude-table in opts" do
       include_examples "for splitting multi value arg", :"exclude-table"
     end
 
     context "with :local_file, :exclude-table-data in opts" do
       include_examples "for splitting multi value arg", :"exclude-table-data"
+    end
+
+    context "with :local_file, :exclude_table_data in opts" do
+      include_examples "for splitting multi value arg", :exclude_table_data
     end
 
     context "with :local_file, :t in opts" do
@@ -153,6 +161,10 @@ describe PostgresAdmin do
 
     context "with :local_file, :exclude-table in opts" do
       include_examples "for splitting multi value arg", :"exclude-schema"
+    end
+
+    context "with :local_file, :exclude_table in opts" do
+      include_examples "for splitting multi value arg", :exclude_schema
     end
   end
 


### PR DESCRIPTION
Allows keys passed in for the `--exclude-table`, `--exclude-table-data` and `--exclude-schema` keys to be passed in as underscored hash keys as well, since `AwesomeSpawn::CommandLineBuilder` will properly convert the keys to the dashed version.

This allows the options passed into `evm_dba.rake` on the main repo to be defined setup as normal underscored hash keys properly, per the request of @Fryguy in https://github.com/ManageIQ/manageiq/pull/17652 (direct link below).


Links
-----

* https://github.com/ManageIQ/manageiq/pull/17652#discussion_r199013548