### PR TITLE
Use --xlog-method=stream for pg_basebackup

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -139,7 +139,7 @@ class PostgresAdmin
 
     FileUtils.mkdir_p(path.dirname)
     Dir.mktmpdir("vmdb_backup", path.dirname) do |dir|
-      runcmd("pg_basebackup", opts, :z => nil, :format => "t", :xlog_method => "fetch", :pgdata => dir)
+      runcmd("pg_basebackup", opts, :z => nil, :format => "t", :xlog_method => "stream", :pgdata => dir)
       FileUtils.mv(File.join(dir, "base.tar.gz"), path)
     end
     path.to_s


### PR DESCRIPTION
Previously we were using the "fetch" method which would fail if
we did not set wal_keep_segments to a high enough value. We were
never setting a value for wal_keep_segments so this would (infrequently)
fail.

https://bugzilla.redhat.com/show_bug.cgi?id=1616022