### PR TITLE
Revert to using --xlog-method fetch for postgres backup

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -139,7 +139,7 @@ class PostgresAdmin
 
     FileUtils.mkdir_p(path.dirname)
     Dir.mktmpdir("vmdb_backup", path.dirname) do |dir|
-      runcmd("pg_basebackup", opts, :z => nil, :format => "t", :xlog_method => "stream", :pgdata => dir)
+      runcmd("pg_basebackup", opts, :z => nil, :format => "t", :xlog_method => "fetch", :pgdata => dir)
       FileUtils.mv(File.join(dir, "base.tar.gz"), path)
     end
     path.to_s


### PR DESCRIPTION
This is because we cannot use the tar option with stream.
We need the backup to be written in a single stream for the work
regarding file splitting and backing up to cloud-based targets to
move forward.

Fixes #366
Reverts #364 

cc @NickLaMuro 