### PR TITLE
Add MiqFtpStorage

### DIFF
--- a/lib/gems/pending/util/miq_object_storage.rb
+++ b/lib/gems/pending/util/miq_object_storage.rb
@@ -6,10 +6,6 @@ class MiqObjectStorage < MiqFileStorage::Interface
   attr_accessor :settings
   attr_writer   :logger
 
-  def self.new_with_opts(opts)
-    new(opts.slice(:uri, :username, :password))
-  end
-
   def initialize(settings)
     raise "URI missing" unless settings.key?(:uri)
     @settings = settings.dup

--- a/lib/gems/pending/util/miq_object_storage.rb
+++ b/lib/gems/pending/util/miq_object_storage.rb
@@ -2,6 +2,7 @@ require 'util/miq_file_storage'
 
 class MiqObjectStorage < MiqFileStorage::Interface
   require 'util/object_storage/miq_s3_storage'
+  require 'util/object_storage/miq_ftp_storage'
 
   attr_accessor :settings
   attr_writer   :logger

--- a/lib/gems/pending/util/object_storage/miq_ftp_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_ftp_storage.rb
@@ -1,0 +1,86 @@
+require 'util/miq_ftp_lib'
+require 'util/miq_object_storage'
+require 'logger'
+
+class MiqFtpStorage < MiqObjectStorage
+  include MiqFtpLib
+
+  attr_reader :uri, :username, :password
+
+  def self.uri_scheme
+    "ftp".freeze
+  end
+
+  def self.new_with_opts(opts)
+    new(opts.slice(:uri, :username, :password))
+  end
+
+  def initialize(settings)
+    super
+    @uri      = @settings[:uri]
+    @username = @settings[:username]
+    @password = @settings[:password]
+  end
+
+  # Override for connection handling
+  def add(*upload_args)
+    with_connection { super }
+  end
+
+  # Override for connection handling
+  def download(*download_args)
+    with_connection { super }
+  end
+
+  # Specific version of Net::FTP#storbinary that doesn't use an existing local
+  # file, and only uploads a specific size (byte_count) from the input_file
+  def upload_single(dest_uri)
+    ftp.synchronize do
+      ftp.send(:with_binary, true) do
+        conn = ftp.send(:transfercmd, "STOR #{uri_to_relative(dest_uri)}")
+        IO.copy_stream(source_input, conn, byte_count)
+        conn.close
+        ftp.send(:voidresp)
+      end
+    end
+    dest_uri
+  rescue Errno::EPIPE
+    # EPIPE, in this case, means that the data connection was unexpectedly
+    # terminated.  Rather than just raising EPIPE to the caller, check the
+    # response on the control connection.  If getresp doesn't raise a more
+    # appropriate exception, re-raise the original exception.
+    ftp.send(:getresp)
+    raise
+  end
+
+  def download_single(source, destination)
+    ftp.getbinaryfile(uri_to_relative(source), destination)
+  end
+
+  def mkdir(dir)
+    create_directory_structure(uri_to_relative(dir))
+  end
+
+  private
+
+  def login_credentials
+    [username, password].compact
+  end
+
+  # Currently assumes you have just connected and are at the root logged in
+  # dir.  Net::FTP (or ftp in general) doesn't seem to have a concept of a
+  # "root dir" based on your login, so this should be used right after
+  # `.connect`, or shortly there after.
+  #
+  # Or, you should be returning to the directory you came from prior to using
+  # this method again, or not using `ftp.chdir` at all.
+  def uri_to_relative(filepath)
+    result = URI.split(filepath)[5]
+    result = result[1..-1] if result[0] == "/".freeze
+    result
+  end
+
+  def _log
+    logger
+  end
+end

--- a/spec/support/contexts/generated_tmp_files.rb
+++ b/spec/support/contexts/generated_tmp_files.rb
@@ -1,0 +1,17 @@
+shared_context "generated tmp files" do
+  let!(:tmpfile_size) { 10.megabytes }
+  let!(:source_path)  { Pathname.new(source_file.path) }
+  let!(:source_file) do
+    Tempfile.new("source_file").tap do |file|
+      file.write("0" * tmpfile_size)
+      file.close
+    end
+  end
+
+  after do
+    source_file.unlink
+    Dir["#{source_path.expand_path}.*"].each do |file|
+      File.delete(file)
+    end
+  end
+end

--- a/spec/support/custom_matchers/exist_on_ftp_server.rb
+++ b/spec/support/custom_matchers/exist_on_ftp_server.rb
@@ -1,0 +1,52 @@
+# Assumes this in run in a :with_ftp_server context so an FTP server on
+# localhost is available.
+#
+# See spec/support/with_ftp_server.rb for more info.
+RSpec::Matchers.define :exist_on_ftp_server do
+  match do |actual|
+    !list_in_ftp(actual).empty?
+  end
+
+  failure_message do |actual|
+    fail_msg(actual)
+  end
+
+  failure_message_when_negated do |actual|
+    fail_msg(actual, :negated => true)
+  end
+
+  def with_connection
+    Net::FTP.open("localhost") do |ftp|
+      ftp.login("ftpuser", "ftppass")
+      yield ftp
+    end
+  end
+
+  # Do searches with Net::FTP instead of normal directory scan (even though we
+  # could) just so we are exercising the FTP interface as expected.
+  def list_in_ftp(file_or_dir)
+    with_connection do |ftp|
+      begin
+        ftp.nlst(to_path_string(file_or_dir))
+      rescue Net::FTPPermError
+        []
+      end
+    end
+  end
+
+  def fail_msg(actual, negated: false)
+    dir     = File.dirname(actual)
+    entries = list_in_ftp(dir)
+    exist   = negated ? "not exist" : "exist"
+    <<~MSG
+      expected: #{to_path_string(actual)} to #{exist} in ftp directory"
+
+      Entries for #{dir}:
+      #{entries.empty? ? "  []" : entries.map { |e| "  #{e}" }.join("\n")}
+    MSG
+  end
+
+  def to_path_string(path)
+    path.try(:path) || URI.split(path.to_s)[5]
+  end
+end

--- a/spec/support/custom_matchers/have_size_on_ftp_server_of.rb
+++ b/spec/support/custom_matchers/have_size_on_ftp_server_of.rb
@@ -1,0 +1,30 @@
+# Assumes this in run in a :with_ftp_server context so an FTP server on
+# localhost is available.
+#
+# See spec/support/with_ftp_server.rb for more info.
+RSpec::Matchers.define :have_size_on_ftp_server_of do |expected|
+  match do |filepath|
+    size = size_on_ftp(filepath)
+    size == expected
+  end
+
+  def with_connection
+    Net::FTP.open("localhost") do |ftp|
+      ftp.login("ftpuser", "ftppass")
+      yield ftp
+    end
+  end
+
+  # Do searches with Net::FTP instead of normal directory scan (even though we
+  # could) just so we are exercising the FTP interface as expected.
+  def size_on_ftp(file_or_dir)
+    path = file_or_dir.try(:path) || URI.split(file_or_dir.to_s)[5]
+    with_connection do |ftp|
+      begin
+        ftp.size(path)
+      rescue Net::FTPPermError
+        0
+      end
+    end
+  end
+end

--- a/spec/util/miq_file_storage_spec.rb
+++ b/spec/util/miq_file_storage_spec.rb
@@ -1,4 +1,5 @@
 require "util/mount/miq_generic_mount_session"
+require "util/miq_object_storage"
 
 describe MiqFileStorage do
   def opts_for_nfs
@@ -13,6 +14,10 @@ describe MiqFileStorage do
 
   def opts_for_glusterfs
     opts[:uri] = "glusterfs://example.com/share/path/to/file.txt"
+  end
+
+  def opts_for_ftp
+    opts[:uri] = "ftp://example.com/share/path/to/file.txt"
   end
 
   def opts_for_fakefs
@@ -63,6 +68,12 @@ describe MiqFileStorage do
       before { opts_for_glusterfs }
 
       include_examples ".with_interface_class implementation", "MiqGlusterfsSession"
+    end
+
+    context "with an ftp:// uri" do
+      before { opts_for_ftp }
+
+      include_examples ".with_interface_class implementation", "MiqFtpStorage"
     end
 
     context "with an unknown uri scheme" do

--- a/spec/util/mount/miq_local_mount_session_spec.rb
+++ b/spec/util/mount/miq_local_mount_session_spec.rb
@@ -2,26 +2,7 @@ require 'util/mount/miq_local_mount_session'
 require 'tempfile'
 
 describe MiqLocalMountSession do
-  shared_context "generated tmp files" do
-    let!(:tmpfile_size) { 10.megabytes }
-    let!(:source_path)  { Pathname.new(source_file.path) }
-    let!(:source_file) do
-      Tempfile.new("source_file").tap do |file|
-        file.write("0" * tmpfile_size)
-        file.close
-      end
-    end
-    let!(:dest_path) do
-      Pathname.new(Dir::Tmpname.create("") {})
-    end
-
-    after do
-      source_file.unlink
-      Dir["#{source_path.expand_path}.*"].each do |file|
-        File.delete(file)
-      end
-    end
-  end
+  let!(:dest_path) { Pathname.new(Dir::Tmpname.create("") {}) }
 
   subject { described_class.new(:uri => "file://") }
 

--- a/spec/util/object_storage/miq_ftp_storage_spec.rb
+++ b/spec/util/object_storage/miq_ftp_storage_spec.rb
@@ -1,0 +1,119 @@
+require 'util/object_storage/miq_ftp_storage.rb'
+
+describe MiqFtpStorage, :with_ftp_server do
+  subject         { described_class.new(ftp_creds.merge(:uri => "ftp://localhost")) }
+  let(:ftp_creds) { { :username => "ftpuser", :password => "ftppass" } }
+
+  describe "#add" do
+    include_context "generated tmp files"
+
+    shared_examples "adding files" do |dest_path|
+      let(:dest_path) { dest_path }
+
+      it "copies single files" do
+        expect(subject.add(source_path.to_s, dest_path.to_s)).to eq(dest_path.to_s)
+        expect(dest_path).to exist_on_ftp_server
+        expect(dest_path).to have_size_on_ftp_server_of(10.megabytes)
+      end
+
+      it "copies file to splits" do
+        expected_splitfiles = (1..5).map do |suffix|
+          "#{dest_path}.0000#{suffix}"
+        end
+
+        File.open(source_path) do |f| # with an IO object this time
+          subject.add(f, dest_path.to_s, "2M")
+        end
+
+        expected_splitfiles.each do |filename|
+          expect(filename).to exist_on_ftp_server
+          expect(filename).to have_size_on_ftp_server_of(2.megabytes)
+        end
+      end
+
+      it "can take input from a command" do
+        expected_splitfiles = (1..5).map do |suffix|
+          "#{dest_path}.0000#{suffix}"
+        end
+
+        subject.add(dest_path.to_s, "2M") do |input_writer|
+          `#{Gem.ruby} -e "File.write('#{input_writer}', '0' * #{tmpfile_size})"`
+        end
+
+        expected_splitfiles.each do |filename|
+          expect(filename).to exist_on_ftp_server
+          expect(filename).to have_size_on_ftp_server_of(2.megabytes)
+        end
+      end
+
+      context "with slightly a slightly smaller input file than 10MB" do
+        let(:tmpfile_size) { 10.megabytes - 1.kilobyte }
+
+        it "properly chunks the file" do
+          expected_splitfiles = (1..10).map do |suffix|
+            "#{dest_path}.%<suffix>05d" % {:suffix => suffix}
+          end
+
+          # using pathnames this time
+          subject.add(source_path, dest_path.to_s, 1.megabyte)
+
+          expected_splitfiles[0, 9].each do |filename|
+            expect(filename).to exist_on_ftp_server
+            expect(filename).to have_size_on_ftp_server_of(1.megabytes)
+          end
+
+          last_split = expected_splitfiles.last
+          expect(last_split).to exist_on_ftp_server
+          expect(last_split).to have_size_on_ftp_server_of(1.megabyte - 1.kilobyte)
+        end
+      end
+    end
+
+    context "using a 'relative path'" do
+      include_examples "adding files", "path/to/file"
+    end
+
+    context "using a 'absolute path'" do
+      include_examples "adding files", "/path/to/my_file"
+    end
+
+    context "using a uri" do
+      include_examples "adding files", "ftp://localhost/foo/bar/baz"
+    end
+  end
+
+  describe "#download" do
+    let(:dest_path)   { Dir::Tmpname.create("") { |name| name } }
+    let(:source_file) { existing_ftp_file(10.megabytes) }
+    let(:source_path) { File.basename(source_file.path) }
+
+    after { File.delete(dest_path) if File.exist?(dest_path) }
+
+    it "downloads the file" do
+      subject.download(dest_path, source_path)
+
+      # Sanity check that what we are downloading is the size we expect
+      expect(source_path).to exist_on_ftp_server
+      expect(source_path).to have_size_on_ftp_server_of(10.megabytes)
+
+      expect(File.exist?(dest_path)).to be true
+      expect(File.stat(dest_path).size).to eq(10.megabytes)
+    end
+
+    it "can take input from a command" do
+      source_data = nil
+      subject.download(nil, source_path) do |input_writer|
+        source_data = `#{Gem.ruby} -e "print File.read('#{input_writer}')"`
+      end
+
+      # Sanity check that what we are downloading is the size we expect
+      # (and we didn't actually download the file to disk)
+      expect(File.exist?(dest_path)).to be false
+      expect(source_path).to exist_on_ftp_server
+      expect(source_path).to have_size_on_ftp_server_of(10.megabytes)
+
+      # Nothing written, just printed the streamed file in the above command
+      expect(source_data.size).to eq(10.megabytes)
+    end
+  end
+end


### PR DESCRIPTION
Built off of https://github.com/ManageIQ/manageiq-gems-pending/pull/360 (only the last two commits are added as a part of this pull request).

This adds the `FTP` protocol as a `ObjectStorage`, and allows it to work with the `MiqFileStorage::Interface`.

~~**Note:**  To any "very eager reviewer", I have a few commits in here at the moment that should live over in the https://github.com/ManageIQ/manageiq-gems-pending/pull/360 PR, but didn't realize I wanted them until I started this effort.  Will probably rebase them out into that other branch tomorrow.~~ Done.


Links
-----
* Built off of (needs to be merged first):
  - [x] https://github.com/ManageIQ/manageiq-gems-pending/pull/365
  - [x] https://github.com/ManageIQ/manageiq-gems-pending/pull/361
  - [x] https://github.com/ManageIQ/manageiq-gems-pending/pull/360