### PR TITLE
Use correct variable name for PostgresAdmin

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -278,7 +278,7 @@ class PostgresAdmin
       message = AwesomeSpawn::CommandResultError.default_message(cmd, exit_status)
       $log.error("AwesomeSpawn: #{message}")
       $log.error("AwesomeSpawn: #{result.error}")
-      raise AwesomeSpawn::CommandResultError.new(message, command_result)
+      raise AwesomeSpawn::CommandResultError.new(message, result)
     end
   ensure
     File.delete(error_path) if File.exist?(error_path)


### PR DESCRIPTION
`command_result` as a local variable  doesn't exist, but `result`
does...

derp...

Links
-----
* Caused by https://github.com/ManageIQ/manageiq-gems-pending/pull/365