### PR TITLE
Changes to MiqPassword.sanitize_string to support URL encoded password.

### DIFF
--- a/lib/gems/pending/util/miq-password.rb
+++ b/lib/gems/pending/util/miq-password.rb
@@ -6,7 +6,8 @@ class MiqPassword
   class MiqPasswordError < StandardError; end
 
   CURRENT_VERSION = "2"
-  REGEXP = /v([0-9]+):\{([^}]*)\}/
+  REGEXP = /v([0-2]):\{([^}]*)\}/
+  REGEXP_PASSWORD = /v[0-2](:\{[^}]*\}|%3A%7B.*?%7D)/ # for "v2:{...}" or its URL encoded string
   REGEXP_START_LINE = /^#{REGEXP}/
 
   attr_reader :encStr
@@ -81,11 +82,11 @@ class MiqPassword
   end
 
   def self.sanitize_string(s)
-    s.gsub(REGEXP, '********')
+    s.gsub(REGEXP_PASSWORD, '********')
   end
 
   def self.sanitize_string!(s)
-    s.gsub!(REGEXP, '********')
+    s.gsub!(REGEXP_PASSWORD, '********')
   end
 
   def self.try_decrypt(str)

--- a/spec/util/miq-password_spec.rb
+++ b/spec/util/miq-password_spec.rb
@@ -212,8 +212,10 @@ describe MiqPassword do
   end
 
   it ".sanitize_string" do
-    expect(MiqPassword.sanitize_string!("some :password: v1:{XAWlcAlViNwB} and another :password: v2:{egr+hObB}")).to eq(
-      "some :password: ******** and another :password: ********")
+    expect(MiqPassword.sanitize_string("some :password: v1:{XAWlcAlViNwB} and another :password: v2:{egr+hObB}"))
+      .to eq("some :password: ******** and another :password: ********")
+    expect(MiqPassword.sanitize_string("some :enocded_password: v1%3A%7BXAWlcAlViNwB%7D and another :enocded_password: v2%3A%7Begr%2BhObB%7D"))
+      .to eq("some :enocded_password: ******** and another :enocded_password: ********")
   end
 
   it ".sanitize_string!" do


### PR DESCRIPTION
To hide the encoded password value in URL encoded string with```*******```.

Blocks https://github.com/ManageIQ/manageiq-automation_engine/pull/228.

https://bugzilla.redhat.com/show_bug.cgi?id=1619385

@miq-bot add_label bug, gaprindashvili/yes

cc @gmcculloug @bdunne 

Before:
```
[----] I, [2018-09-04T11:52:44.679450 #12292:c27108]  INFO -- : Q-task_id([service_template_provision_task_1]) Instantiating [/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization?MiqServer%3A%3Amiq_server=1&Service%3A%3AService=1&ServiceTemplateProvisionTask%3A%3Aservice_template_provision_task=1&User%3A%3Auser=1&ae_state=checkprovisioned&ae_state_previous=---%0A%22%2FManageIQ%2FService%2FProvisioning%2FStateMachines%2FServiceProvision_Template%2FCatalogItemInitialization%22%3A%0A%20%20ae_state%3A%20checkprovisioned%0A%20%20ae_state_retries%3A%201%0A%20%20ae_state_started%3A%202018-09-04%2015%3A51%3A41%20UTC%0A%20%20ae_state_max_retries%3A%20100%0A&ae_state_retries=1&ae_state_started=2018-09-04%2015%3A51%3A41%20UTC&object_name=CatalogItemInitialization&password%3A%3Adialog_password_field=v2%3A%7BSEZAjnaOSeyzt387%2FrAooQ%3D%3D%7D&request=clone_to_service&service_action=Provision&vmdb_object_type=service_template_provision_task]
```
After:
```
[----] I, [2018-09-04T11:52:44.679450 #12292:c27108]  INFO -- : Q-task_id([service_template_provision_task_1]) Instantiating [/Service/Provisioning/StateMachines/ServiceProvision_Template/CatalogItemInitialization?MiqServer%3A%3Amiq_server=1&Service%3A%3AService=1&ServiceTemplateProvisionTask%3A%3Aservice_template_provision_task=1&User%3A%3Auser=1&ae_state=checkprovisioned&ae_state_previous=---%0A%22%2FManageIQ%2FService%2FProvisioning%2FStateMachines%2FServiceProvision_Template%2FCatalogItemInitialization%22%3A%0A%20%20ae_state%3A%20checkprovisioned%0A%20%20ae_state_retries%3A%201%0A%20%20ae_state_started%3A%202018-09-04%2015%3A51%3A41%20UTC%0A%20%20ae_state_max_retries%3A%20100%0A&ae_state_retries=1&ae_state_started=2018-09-04%2015%3A51%3A41%20UTC&object_name=CatalogItemInitialization&password%3A%3Adialog_password_field=********&request=clone_to_service&service_action=Provision&vmdb_object_type=service_template_provision_task]
```