### PR TITLE
Don't set empty ENV values for database dumps

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -249,7 +249,7 @@ class PostgresAdmin
     {
       "PGUSER"     => opts[:username],
       "PGPASSWORD" => opts[:password]
-    }
+    }.delete_blanks
   end
   # rubocop:disable Style/SymbolArray
   PG_DUMP_MULTI_VALUE_ARGS = [


### PR DESCRIPTION
Currently, `PGUSER` and `PGPASSWORD` are set in the environment.
We want these values to pass through to the subshells

### Before

`$PGUSER` was overridden by `""` if `--dbuser` was not passed into the rake task

### After

The existing `$PGUSER` value is used if there is no `--dbuser` passed in, but the new value is used if one is passed in.
(same goes for `$PGPASSWORD`)


related to:
- https://bugzilla.redhat.com/show_bug.cgi?id=1632433
- ManageIQ/manageiq-appliance_console#65
