### PR TITLE
Add stdin option to shell_exec

### DIFF
--- a/lib/gems/pending/util/MiqSshUtil.rb
+++ b/lib/gems/pending/util/MiqSshUtil.rb
@@ -233,9 +233,9 @@ class MiqSshUtil
     raise MiqException::MiqSshUtilHostKeyMismatch
   end
 
-  def shell_exec(cmd, doneStr = nil, _shell = nil)
-    return exec(cmd, doneStr) if @su_user.nil?
-    ret = suexec(cmd, doneStr)
+  def shell_exec(cmd, doneStr = nil, _shell = nil, stdin = nil)
+    return exec(cmd, doneStr, stdin) if @su_user.nil?
+    ret = suexec(cmd, doneStr, stdin)
     # Remove escape character from the end of the line
     ret.sub!(/\e$/, '')
     ret


### PR DESCRIPTION
This PR is a follow up of https://github.com/ManageIQ/manageiq-gems-pending/pull/379 that adds support for `stdin` to `shell_exec` method, as `exec` and `su_exec` are mostly hidden by `shell_exec`. This is also used in [ManageIQ/manageiq#18064/](https://github.com/ManageIQ/manageiq/pull/18064/): [app/models/conversion_host.rb:42](https://github.com/ManageIQ/manageiq/pull/18064/files#diff-02f7c651ed336a288d5c05feffcf761bR42).