### PR TITLE
Be more lenient for locked down ftp servers

### DIFF
--- a/lib/gems/pending/util/miq_ftp_lib.rb
+++ b/lib/gems/pending/util/miq_ftp_lib.rb
@@ -56,7 +56,11 @@ module MiqFtpLib
       end
       ftp.chdir(directory)
     end
-    ftp.chdir(pwd)
+  rescue Net::FTPPermError
+    raise unless @username.nil? && @password.nil?
+    _log.info("introspection of directories disabled. skipping create_directory_structure")
+  ensure
+    ftp.chdir(pwd) if pwd
   end
 
   def with_connection(cred_hash = nil)


### PR DESCRIPTION
When uploading to an anonymous ftp server, sometimes ls (aka `nlst`) is disabled.

This logs that case and continues on

this is part of anonymous ftp feature
https://bugzilla.redhat.com/show_bug.cgi?id=1632433

@miq-bot add_label enhancement