### PR TITLE
Handle pipes for pg_restore

### DIFF
--- a/lib/gems/pending/util/postgres_admin.rb
+++ b/lib/gems/pending/util/postgres_admin.rb
@@ -173,8 +173,23 @@ class PostgresAdmin
 
   def self.restore_pg_dump(opts)
     recreate_db(opts)
+    args = { :verbose => nil, :exit_on_error => nil }
 
-    runcmd("pg_restore", opts, :verbose => nil, :exit_on_error => nil, nil => opts[:local_file])
+    if File.pipe?(opts[:local_file])
+      cmd_args   = combine_command_args(opts, args)
+      cmd        = AwesomeSpawn.build_command_line("pg_restore", cmd_args)
+      error_path = Dir::Tmpname.create("") { |tmpname| tmpname }
+      spawn_args = { :err => error_path, :in => [opts[:local_file].to_s, "rb"] }
+
+      $log.info("MIQ(#{name}.#{__method__}) Running command... #{cmd}")
+      process_thread = Process.detach(Kernel.spawn(pg_env(opts), cmd, spawn_args))
+      process_status = process_thread.value
+
+      handle_error(cmd, process_status.exitstatus, error_path)
+    else
+      args[nil] = opts[:local_file]
+      runcmd("pg_restore", opts, args)
+    end
     opts[:local_file]
   end
 

--- a/spec/util/postgres_admin_spec.rb
+++ b/spec/util/postgres_admin_spec.rb
@@ -1,3 +1,4 @@
+require "fileutils"
 require "util/postgres_admin"
 
 describe PostgresAdmin do
@@ -9,8 +10,31 @@ describe PostgresAdmin do
 
       it "restores all of the tables to the new database name" do
         restore_opts = RestoreHelper.default_restore_dump_opts.dup
-        restore_opts[:dbname] = "pg_dump_restore_of_simple_db"
+        restore_opts[:dbname] = dbname
         PostgresAdmin.restore(restore_opts)
+
+        expect(author_count).to eq(2)
+        expect(book_count).to   eq(3)
+      end
+    end
+
+    context "with a pg_dump file from a pipe" do
+      let(:dbname)    { "pg_dump_restore_of_simple_db_from_pipe" }
+      let(:fifo_path) { Pathname.new(Dir::Tmpname.create("") {}) }
+
+      after { FileUtils.rm_rf(fifo_path) if File.exist?(fifo_path) }
+
+      it "restores all of the tables to the new database name" do
+        expect(PostgresAdmin).to receive(:pg_dump_file?).and_return(true)
+
+        File.mkfifo(fifo_path)
+        restore_opts = RestoreHelper.default_restore_dump_opts.dup
+        restore_opts[:dbname]     = dbname
+        restore_opts[:local_file] = fifo_path
+
+        thread = Thread.new { IO.copy_stream(RestoreHelper::PG_DUMPFILE, fifo_path) }
+        PostgresAdmin.restore(restore_opts)
+        thread.join
 
         expect(author_count).to eq(2)
         expect(book_count).to   eq(3)


### PR DESCRIPTION
This is built off of #385

Better diff can be found here:

https://github.com/NickLaMuro/manageiq-gems-pending/compare/postgres_admin_restore_and_dump_specs...handle-piping-for-postgres-admin-restore-pg-dump

* * *


For whatever the reason, `pg_dump` doesn't like reading from a fifo when it isn't passed in as `STDIN`.  This assigns the same treatment to it as was done to `pg_dump`/`pg_restore`, which is passes it through `STDIN`.

Since we don't really have good access to STDIN via `AwesomeSpawn`, we use vanilla `Kernel.spawn` to handle the actually command execution.  We call out to `AwesomeSpawn` for the command builder, as well as emulate the errors that it would throw so there is limited change in how this library behaves to the user.