### PR TITLE
Revert "Merge pull request #391 from agrare/revert_bump_fog-openstack"

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "aws-sdk",                 "~> 2.9.7"
   s.add_runtime_dependency "binary_struct",           "~> 2.1"
   s.add_runtime_dependency "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
-  s.add_runtime_dependency "fog-openstack",           "~> 0.1.22"
+  s.add_runtime_dependency "fog-openstack",           "~> 0.3"
   s.add_runtime_dependency "linux_admin",             "~> 1.0"
   s.add_runtime_dependency "mime-types",              "~> 3.0"
   s.add_runtime_dependency "minitar",                 "~> 0.6"


### PR DESCRIPTION
This reverts commit 5f549aaac85ba9d23c13cc89d42d2767b2a5ad9d, reversing
changes made to 1bffaf4aba60e32cb3d23e2a2bdc7d7caf8cec4c.

Required now that https://github.com/ManageIQ/manageiq-providers-openstack/pull/334 is merged