### PR TITLE
[MiqGenericMountSession] Support @byte_count in #download_single

### DIFF
--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -301,7 +301,7 @@ class MiqGenericMountSession < MiqFileStorage::Interface
       end
 
       logger.info("#{log_header} Copying file [#{relpath}] to [#{local_file}]...")
-      IO.copy_stream(relpath, local_file)
+      IO.copy_stream(relpath, local_file, byte_count)
       logger.info("#{log_header} Copying file [#{relpath}] to [#{local_file}] complete")
     rescue => err
       msg = "Downloading [#{remote_file}] to [#{local_file}], failed due to error: '#{err.message}'"

--- a/spec/util/mount/miq_local_mount_session_spec.rb
+++ b/spec/util/mount/miq_local_mount_session_spec.rb
@@ -88,5 +88,18 @@ describe MiqLocalMountSession do
       expect(source_data.size).to eq(10.megabytes)
       expect(source_data).to eq(File.read(source_path))
     end
+
+    # Note, we are using `#download` in the spec, but really, this is a feature
+    # for `#download_single`.  `#download` really doesn't make use of this
+    # directly.
+    it "respects the `byte_count` attribute" do
+      downloaded_data = StringIO.new
+
+      subject.instance_variable_set(:@byte_count, 42)
+      subject.download(downloaded_data, source_path)
+
+      expect(downloaded_data.string.size).to eq(42)
+      expect(downloaded_data.string).to      eq("0" * 42)
+    end
   end
 end


### PR DESCRIPTION
Updates `MiqGenericMountSession#download_single` to support the `byte_count` attribute.  If passed, it will only download the specified number of bytes to the `destination`.

Since we are using `IO.copy_stream`, this is fairly straight forward, and works with basically any `IO`-like object.: