### PR TITLE
[MiqFtpStorage] Support @byte_count in #download_single

### DIFF
--- a/spec/util/object_storage/miq_ftp_storage_spec.rb
+++ b/spec/util/object_storage/miq_ftp_storage_spec.rb
@@ -115,5 +115,21 @@ describe MiqFtpStorage, :with_ftp_server do
       # Nothing written, just printed the streamed file in the above command
       expect(source_data.size).to eq(10.megabytes)
     end
+
+    # Note, we are using `#download` in the spec, but really, this is a feature
+    # for `#download_single`.  `#download` really doesn't make use of this
+    # directly.
+    it "respects the `byte_count` attribute" do
+      downloaded_data = StringIO.new
+      subject.instance_variable_set(:@byte_count, 42)
+      subject.download(downloaded_data, source_path)
+
+      # Sanity check that what we are downloading is the size we expect
+      expect(source_path).to exist_on_ftp_server
+      expect(source_path).to have_size_on_ftp_server_of(10.megabytes)
+
+      expect(downloaded_data.string.size).to eq(42)
+      expect(downloaded_data.string).to      eq("0" * 42)
+    end
   end
 end


### PR DESCRIPTION
Since there is no way in the spec of `Net::FTP#getbinaryfile` to only download a specified number of bytes, it was required to rework a form of `Net::FTP#retrbinary` (a private method of that class) to allow only reading from the socket for the specified number of bytes, then moving on.

The goal was to remain consistent with `#add` and continue to use `IO.copy_stream`, a slight tweak that was necessary to get that working.  The `conn` variable is a `BufferedSocket`, which basically has IO like, but wraps an existing `@io` with some methods and tries to maintain a IO-like class interface.

Unfortunately, it's `#read` implementation doesn't have the same number of args as `IO#read`:

```
(method definitions)

IO#read( [ length, [ output ] ] )

BufferedSocket#read( [ len ] )
```

When `IO.copy_stream` calls `#read` under the covers, it does pass in the second argument of `output` to the result, which in turn causes an error if we just pass `conn` as the first argument to `copy_stream`.

The underlying `@io` attribute for `conn` does actually adhere to the argument interface of `copy_stream`, and since we don't miss anything by working around it, we just used that instead for our use here.  This should, however, probably be fixed in ruby's stdlib for `Net::FTP`.