### PR TITLE
Fixes some bugs with MiqS3Storage#download_single

### DIFF
--- a/lib/gems/pending/util/object_storage/miq_s3_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_s3_storage.rb
@@ -46,7 +46,7 @@ class MiqS3Storage < MiqObjectStorage
     with_standard_s3_error_handling("downloading", source) do
       if destination.kind_of?(IO)
         s3.client.get_object(:bucket => bucket_name, :key => object_key) do |chunk|
-          destination.write(chunk)
+          destination.write(chunk.force_encoding(destination.external_encoding))
         end
       else # assume file path
         bucket.object(source).download_file(destination)

--- a/lib/gems/pending/util/object_storage/miq_s3_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_s3_storage.rb
@@ -40,7 +40,7 @@ class MiqS3Storage < MiqObjectStorage
   end
 
   def download_single(source, destination)
-    object_key = uri_to_object_key(remote_file)
+    object_key = uri_to_object_key(source)
     logger.debug("Downloading [#{source}] from bucket [#{bucket_name}] to local file [#{destination}]")
 
     with_standard_s3_error_handling("downloading", source) do

--- a/lib/gems/pending/util/object_storage/miq_s3_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_s3_storage.rb
@@ -52,7 +52,6 @@ class MiqS3Storage < MiqObjectStorage
         bucket.object(source).download_file(destination)
       end
     end
-    local_file
   end
 
   # no-op mostly


### PR DESCRIPTION
The following have been addressed:

- Usage of `remote_file` (wrong variable name) switched to `source` (correct)
- Removes unassigned variable `local_file` from being the return value (mistakenly copied from #upload_single`).
  - The return value isn't currently used for this method, so it has not been replaced.
- Force encoding of the streamed chunks to match the encoding of the destination IO