### PR TITLE
Fixes and cleanup for MiqSwiftStorage

### DIFF
--- a/lib/gems/pending/util/object_storage/miq_swift_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_swift_storage.rb
@@ -16,12 +16,15 @@ class MiqSwiftStorage < MiqObjectStorage
     @bucket_name = URI(@settings[:uri]).host
 
     raise "username and password are required values!" if @settings[:username].nil? || @settings[:password].nil?
-    _scheme, _userinfo, @host, @port, _registry, @mount_path, _opaque, query, _fragment = URI.split(URI.encode(@settings[:uri]))
+    _scheme, _userinfo, @host, @port, _registry, path, _opaque, query, _fragment = URI.split(URI.encode(@settings[:uri]))
     query_params(query) if query
     @swift          = nil
     @username       = @settings[:username]
     @password       = @settings[:password]
-    @container_name = @mount_path[0] == File::Separator ? @mount_path[1..-1] : @mount_path
+
+    # Omit leading slash (if it exists), and grab the rest of the characters
+    # before the next file separator
+    @container_name = path.gsub(/^\/?([^\/]+)\/.*/, '\1')
   end
 
   def uri_to_object_path(remote_file)

--- a/lib/gems/pending/util/object_storage/miq_swift_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_swift_storage.rb
@@ -55,15 +55,17 @@ class MiqSwiftStorage < MiqObjectStorage
       }
       #
       # Because of how `Fog::OpenStack` (and probably `Fog::Core`) is designed,
-      # it has hidden the functionality to provide a block for streaming uploads
-      # that is available out of the box with Excon.
+      # it has hidden the functionality to provide a block for streaming
+      # uploads that is available out of the box with Excon.
       #
       # we use .send here because #request is private
-      # we can't use #put_object (public) directly because it doesn't allow a 202 response code,
-      # which is what swift responds with when we pass it the :request_block
-      # (This allows us to stream the response in chunks)
+      #
+      # we can't use #put_object (public) directly because it doesn't allow a
+      # 202 response code, which is what swift responds with when we pass it
+      # the :request_block (This allows us to stream the response in chunks)
       #
       swift_file.service.send(:request, params)
+
       clear_split_vars
     rescue Excon::Errors::Unauthorized => err
       msg = "Access to Swift container #{@container_name} failed due to a bad username or password. #{err}"

--- a/spec/util/object_storage/miq_swift_storage_spec.rb
+++ b/spec/util/object_storage/miq_swift_storage_spec.rb
@@ -3,17 +3,33 @@ require "util/object_storage/miq_swift_storage"
 describe MiqSwiftStorage do
   let(:object_storage) { described_class.new(:uri => uri, :username => 'user', :password => 'pass') }
 
-  context "using a uri without query parameters" do
-    let(:uri) { "swift://foo.com/abc/def" }
+  describe "#initialize" do
+    context "using a uri with query parameters" do
+      let(:uri) { "swift://foo.com:5678/abc/def?region=region&api_version=v3&security_protocol=non-ssl" }
 
-    it "#initialize sets the container_name" do
-      container_name = object_storage.container_name
-      expect(container_name).to eq("abc/def")
+      it "#initialize sets the container_name" do
+        container_name = object_storage.container_name
+        expect(container_name).to eq("abc")
+      end
+
+      it "#uri_to_object_path returns a new object path" do
+        result = object_storage.uri_to_object_path(uri)
+        expect(result).to eq("def")
+      end
     end
 
-    it "#uri_to_object_path returns a new object path" do
-      result = object_storage.uri_to_object_path(uri)
-      expect(result).to eq("def")
+    context "using a uri without query parameters" do
+      let(:uri) { "swift://foo.com/abc/def/my_file.tar.gz" }
+
+      it "#initialize sets the container_name" do
+        container_name = object_storage.container_name
+        expect(container_name).to eq("abc")
+      end
+
+      it "#uri_to_object_path returns a new object path" do
+        result = object_storage.uri_to_object_path(uri)
+        expect(result).to eq("def/my_file.tar.gz")
+      end
     end
   end
 


### PR DESCRIPTION
- Fixes a bug with `@container_name` generation (didn't properly handle nested keys
  - "Simplifies" the code a bit too (depends on your affinity for regular expressions I guess...)
- Aligns comments to a standard 80 character width, with a few tweaks.