### PR TITLE
[MiqS3Storage] Support @byte_count in #download_single

### DIFF
--- a/lib/gems/pending/util/object_storage/miq_s3_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_s3_storage.rb
@@ -45,7 +45,14 @@ class MiqS3Storage < MiqObjectStorage
 
     with_standard_s3_error_handling("downloading", source) do
       if destination.kind_of?(IO) || destination.kind_of?(StringIO)
-        s3.client.get_object(:bucket => bucket_name, :key => object_key) do |chunk|
+        get_object_opts = {
+          :bucket => bucket_name,
+          :key    => object_key
+        }
+        # :range is indexed starting at zero
+        get_object_opts[:range] = "bytes=0-#{byte_count - 1}" if byte_count
+
+        s3.client.get_object(get_object_opts) do |chunk|
           destination.write(chunk.force_encoding(destination.external_encoding))
         end
       else # assume file path

--- a/lib/gems/pending/util/object_storage/miq_s3_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_s3_storage.rb
@@ -44,7 +44,7 @@ class MiqS3Storage < MiqObjectStorage
     logger.debug("Downloading [#{source}] from bucket [#{bucket_name}] to local file [#{destination}]")
 
     with_standard_s3_error_handling("downloading", source) do
-      if destination.kind_of?(IO)
+      if destination.kind_of?(IO) || destination.kind_of?(StringIO)
         s3.client.get_object(:bucket => bucket_name, :key => object_key) do |chunk|
           destination.write(chunk.force_encoding(destination.external_encoding))
         end


### PR DESCRIPTION
Built off of https://github.com/ManageIQ/manageiq-gems-pending/pull/397 (this branch will most likely need to be rebased after that is merged)

Simply supports byte_count by passing the `:range` attribute to `#get_object`, as defined here:

https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#get_object-instance_method

Also, will require support `StringIO` in the future, so that change was made here as well.


Links
-----

* Source branch:  https://github.com/ManageIQ/manageiq-gems-pending/pull/397
* `aws-sdk` docs:  https://docs.aws.amazon.com/sdk-for-ruby/v3/api/Aws/S3/Client.html#get_object-instance_method