### PR TITLE
[MiqFileStorage] Add #magic_number_for

### DIFF
--- a/lib/gems/pending/util/object_storage/miq_ftp_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_ftp_storage.rb
@@ -32,6 +32,11 @@ class MiqFtpStorage < MiqObjectStorage
     with_connection { super }
   end
 
+  # Override for connection handling
+  def magic_number_for(*magic_number_for_args)
+    with_connection { super }
+  end
+
   # Specific version of Net::FTP#storbinary that doesn't use an existing local
   # file, and only uploads a specific size (byte_count) from the input_file
   def upload_single(dest_uri)

--- a/spec/util/mount/miq_local_mount_session_spec.rb
+++ b/spec/util/mount/miq_local_mount_session_spec.rb
@@ -88,18 +88,25 @@ describe MiqLocalMountSession do
       expect(source_data.size).to eq(10.megabytes)
       expect(source_data).to eq(File.read(source_path))
     end
+  end
 
-    # Note, we are using `#download` in the spec, but really, this is a feature
-    # for `#download_single`.  `#download` really doesn't make use of this
-    # directly.
-    it "respects the `byte_count` attribute" do
-      downloaded_data = StringIO.new
+  describe "#magic_number_for" do
+    include_context "generated tmp files"
 
-      subject.instance_variable_set(:@byte_count, 42)
-      subject.download(downloaded_data, source_path)
+    it "returns 256 bytes by default" do
+      result = subject.magic_number_for(source_path)
 
-      expect(downloaded_data.string.size).to eq(42)
-      expect(downloaded_data.string).to      eq("0" * 42)
+      expect(result.size).to eq(256)
+      expect(result).to      eq("0" * 256)
+    end
+
+    describe "with a hash of accepted magics" do
+      it "returns key for the passed in magic number value" do
+        magics = { :zero => "000", :one => "1", :foo => "bar" }
+        result = subject.magic_number_for(source_path, :accepted => magics)
+
+        expect(result).to eq(:zero)
+      end
     end
   end
 end

--- a/spec/util/object_storage/miq_ftp_storage_spec.rb
+++ b/spec/util/object_storage/miq_ftp_storage_spec.rb
@@ -115,21 +115,26 @@ describe MiqFtpStorage, :with_ftp_server do
       # Nothing written, just printed the streamed file in the above command
       expect(source_data.size).to eq(10.megabytes)
     end
+  end
 
-    # Note, we are using `#download` in the spec, but really, this is a feature
-    # for `#download_single`.  `#download` really doesn't make use of this
-    # directly.
-    it "respects the `byte_count` attribute" do
-      downloaded_data = StringIO.new
-      subject.instance_variable_set(:@byte_count, 42)
-      subject.download(downloaded_data, source_path)
+  describe "#magic_number_for" do
+    let(:source_file) { existing_ftp_file(10.megabytes) }
+    let(:source_path) { File.basename(source_file.path) }
 
-      # Sanity check that what we are downloading is the size we expect
-      expect(source_path).to exist_on_ftp_server
-      expect(source_path).to have_size_on_ftp_server_of(10.megabytes)
+    it "returns 256 bytes by default" do
+      result = subject.magic_number_for(source_path)
 
-      expect(downloaded_data.string.size).to eq(42)
-      expect(downloaded_data.string).to      eq("0" * 42)
+      expect(result.size).to eq(256)
+      expect(result).to      eq("0" * 256)
+    end
+
+    describe "with a hash of accepted magics" do
+      it "returns key for the passed in magic number value" do
+        magics = { :zero => "000", :one => "1", :foo => "bar" }
+        result = subject.magic_number_for(source_path, :accepted => magics)
+
+        expect(result).to eq(:zero)
+      end
     end
   end
 end


### PR DESCRIPTION
Used to determine the magic number for a remote uri.


Implementation Notes/Details:
-----------------------------

- Only works for magics that are determined by the first N bytes currently.
- By default, just returns the first 256 bytes
- The `:accepted` param can be passed, which allows you to pass a hash with the values of the hash being the magic values (returns matching key)
  - When passed, only the largest magic's size in data will be returned by the request
- Relies on `#download_single` being able to support a specific `@byte_count` to download only what is necessary and writing to a `StringIO`.


Links
-----

- The following PRs should be merged in order for this function on all file storages:
  - https://github.com/ManageIQ/manageiq-gems-pending/pull/395 (All Mount types)
  - https://github.com/ManageIQ/manageiq-gems-pending/pull/396 (FTP)
  - https://github.com/ManageIQ/manageiq-gems-pending/pull/399 (S3)
  - https://github.com/ManageIQ/manageiq-gems-pending/pull/400 (Swift)