### PR TITLE
Use Gem::Package for tar pg restore unpacking via download streaming

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -30,7 +30,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "fog-openstack",           "~> 0.3"
   s.add_runtime_dependency "linux_admin",             "~> 1.0"
   s.add_runtime_dependency "mime-types",              "~> 3.0"
-  s.add_runtime_dependency "minitar",                 "~> 0.6"
   s.add_runtime_dependency "more_core_extensions",    "~> 3.4"
   s.add_runtime_dependency "net-scp",                 "~> 1.2.1"
   s.add_runtime_dependency "net-sftp",                "~> 2.1.2"


### PR DESCRIPTION
This requires https://github.com/ManageIQ/manageiq-gems-pending/pull/405 to be merged to function properly with files streams.

This change has a few benefits:

- It removes the dependency for an external gem, `minitar` (minor, but nice)
- It supports streaming files (important)

The first was simply a side affect, though one I admit I am happy with the result about, but unfortunately was a required change to allow me to do this without too much custom code.

`Archive::Tar::Minitar.unpack` does not support IO objects that don't use `rewind`, since it uses `Archive::Tar::Minitar::Input` under the hood:

- https://github.com/halostatue/minitar/blob/41c3ca65/lib/archive/tar/minitar.rb#L249
- https://github.com/halostatue/minitar/blob/41c3ca65/lib/archive/tar/minitar/input.rb#L6-L7

The main code that we wanted from the codebase, however, was the `extract_entry` method from `Input`:

- https://github.com/halostatue/minitar/blob/41c3ca65/lib/archive/tar/minitar/input.rb#L117

Which again, requires an `Input` model, and the check for if the `@io` is "seekable" is done on instantiation:

- https://github.com/halostatue/minitar/blob/41c3ca65/lib/archive/tar/minitar/input.rb#L76-L78

`Gem::Package.extract_tar_gz` method, however, only requires instantiating a instance with a "gem name", which doesn't even have to be a real gem, and then we have access to the method without worry, and can pass in our own `IO` object as we see fit.

That said, it isn't ideal, but the alternative would be re-writing one of these two methods:

- https://github.com/halostatue/minitar/blob/41c3ca65/lib/archive/tar/minitar/input.rb#L117-L194
- https://github.com/rubygems/rubygems/blob/master/lib/rubygems/package.rb#L381-L418

In which LJ probably wouldn't approve of all of the additions...

* * *

Of note, and a minor "fun fact":  The code for `minitar` is based on the same person's code, Mauricio Julio Fernández Pradier, as is found in `rubygems`:

- https://github.com/halostatue/minitar/blob/41c3ca65/README.rdoc#L37
- https://github.com/halostatue/minitar/blob/41c3ca65/Licence.md#L7
- https://github.com/rubygems/rubygems/blob/d43e4d01/lib/rubygems/package/tar_reader.rb#L4