### PR TITLE
Fixes to swift storage

### DIFF
--- a/lib/gems/pending/util/object_storage/miq_swift_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_swift_storage.rb
@@ -43,7 +43,8 @@ class MiqSwiftStorage < MiqObjectStorage
     # write dump file to swift
     #
     logger.debug("Writing [#{source_input}] to => Bucket [#{container_name}] using object file name [#{object_file}]")
-    begin
+
+    with_standard_swift_error_handling("uploading") do
       swift_file = container.files.new(:key => object_file)
       params     = {
         :expects       => [201, 202],
@@ -67,14 +68,6 @@ class MiqSwiftStorage < MiqObjectStorage
       swift_file.service.send(:request, params)
 
       clear_split_vars
-    rescue Excon::Errors::Unauthorized => err
-      msg = "Access to Swift container #{@container_name} failed due to a bad username or password. #{err}"
-      logger.error(msg)
-      raise err, msg, err.backtrace
-    rescue => err
-      msg = "Error uploading #{source_input} to Swift container #{@container_name}. #{err}"
-      logger.error(msg)
-      raise err, msg, err.backtrace
     end
   end
 
@@ -175,5 +168,17 @@ class MiqSwiftStorage < MiqObjectStorage
   def query_params(query_string)
     parts = URI.decode_www_form(query_string).to_h
     @region, @api_version, @domain_id, @security_protocol = parts.values_at("region", "api_version", "domain_id", "security_protocol")
+  end
+
+  def with_standard_swift_error_handling(action)
+    yield
+  rescue Excon::Errors::Unauthorized => err
+    msg = "Access to Swift container #{@container_name} failed due to a bad username or password. #{err}"
+    logger.error(msg)
+    raise err, msg, err.backtrace
+  rescue => err
+    msg = "Error #{action} #{source_input} to Swift container #{@container_name}. #{err}"
+    logger.error(msg)
+    raise err, msg, err.backtrace
   end
 end

--- a/lib/gems/pending/util/object_storage/miq_swift_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_swift_storage.rb
@@ -24,7 +24,7 @@ class MiqSwiftStorage < MiqObjectStorage
 
     # Omit leading slash (if it exists), and grab the rest of the characters
     # before the next file separator
-    @container_name = path.gsub(/^\/?([^\/]+)\/.*/, '\1')
+    @container_name = path.gsub(/^\/?([^\/]+).*/, '\1')
   end
 
   def uri_to_object_path(remote_file)

--- a/spec/util/object_storage/miq_swift_storage_spec.rb
+++ b/spec/util/object_storage/miq_swift_storage_spec.rb
@@ -29,6 +29,34 @@ describe MiqSwiftStorage do
         expect(result).to eq("def/my_file.tar.gz")
       end
     end
+
+    context "using a uri with only a container_name" do
+      let(:uri) { "swift://foo.com/container_name" }
+
+      it "sets the container_name" do
+        expect(object_storage.container_name).to eq("container_name")
+      end
+    end
+
+    context "using a uri with only a container_name and params" do
+      let(:uri) { "swift://foo.com/container_name?region=region&api_version=v3&security_protocol=non-ssl" }
+
+      it "sets the container_name" do
+        expect(object_storage.container_name).to eq("container_name")
+      end
+
+      it "sets the region" do
+        expect(object_storage.instance_variable_get(:@region)).to eq("region")
+      end
+
+      it "sets the api_version" do
+        expect(object_storage.instance_variable_get(:@api_version)).to eq("v3")
+      end
+
+      it "sets the security_protocol" do
+        expect(object_storage.instance_variable_get(:@security_protocol)).to eq("non-ssl")
+      end
+    end
   end
 
   describe "#auth_url (private)" do

--- a/spec/util/object_storage/miq_swift_storage_spec.rb
+++ b/spec/util/object_storage/miq_swift_storage_spec.rb
@@ -7,9 +7,8 @@ describe MiqSwiftStorage do
     context "using a uri with query parameters" do
       let(:uri) { "swift://foo.com:5678/abc/def?region=region&api_version=v3&security_protocol=non-ssl" }
 
-      it "#initialize sets the container_name" do
-        container_name = object_storage.container_name
-        expect(container_name).to eq("abc")
+      it "sets the container_name" do
+        expect(object_storage.container_name).to eq("abc")
       end
 
       it "#uri_to_object_path returns a new object path" do
@@ -21,9 +20,8 @@ describe MiqSwiftStorage do
     context "using a uri without query parameters" do
       let(:uri) { "swift://foo.com/abc/def/my_file.tar.gz" }
 
-      it "#initialize sets the container_name" do
-        container_name = object_storage.container_name
-        expect(container_name).to eq("abc")
+      it "sets the container_name" do
+        expect(object_storage.container_name).to eq("abc")
       end
 
       it "#uri_to_object_path returns a new object path" do


### PR DESCRIPTION
Adds a few fixes to the `MiqSwiftStorage`:

* Adds missing commit that was meant to be a part of #400 (eb533f49)
  - `#download_single` expected `#with_standard_swift_error_handling` to be there, and bombs without it
* Adds fix for `@container_name` regexp (242bf6ff)
  - Without this, this would cause all `MiqSwiftStorage` instances that weren't instantiated with a multi-level nested URI (so a URI with a path of something like `/path/file.rb` instead of `/path`) to break, since they would not properly remove the leading slash based on the regexp (previous version expected a trailing slash to some degree in `path`, so `/path/other/things` or `/path/`).
  - The capture group in the regexp, `([^\/]+)` already greedily grabs all of the non-slash characters it can, so there is no need to have this extra slash check following it, since we would delete it anyway.


Links
-----

* Previous PRs
  - Previous fixes to `MiqSwiftStorage`: https://github.com/ManageIQ/manageiq-gems-pending/pull/398
  - Adding `MiqSwiftStorage#download_single`: https://github.com/ManageIQ/manageiq-gems-pending/pull/400
