### PR TITLE
Add documentation to the MiqSshUtil class

### DIFF
--- a/lib/gems/pending/util/MiqSshUtil.rb
+++ b/lib/gems/pending/util/MiqSshUtil.rb
@@ -276,6 +276,14 @@ class MiqSshUtil
     end
   end # suexec
 
+  # Creates a local temporary file under /var/tmp with +cmd+ as its contents.
+  # The tempfile name is the name of the command with "miq-" prepended and ".sh"
+  # appended to the end.
+  #
+  # The end result is a string meant to be run via the suexec method. For example:
+  #
+  # "chmod 700 /var/tmp/miq-foo.sh; /var/tmp/miq-foo.sh; rm -f /var/tmp/miq-foo.sh
+  #
   def temp_cmd_file(cmd)
     temp_remote_script = Tempfile.new(["miq-", ".sh"], "/var/tmp")
     temp_file          = temp_remote_script.path
@@ -289,6 +297,19 @@ class MiqSshUtil
     end
   end
 
+  # Shortcut method that creates and yields an MiqSshUtil object, with the +host+,
+  # +remote_user+ and +remote_password+ options passed in as the first three
+  # params to the constructor, while the +su_user+ and +su_password+ parameters are
+  # automatically set the :su_user and :su_password options. Remaining options are
+  # are passed normally.
+  #
+  # This method is functionally identical to:
+  #
+  #   MiqSshUtil.new(host, remote_user, remote_password, {:su_user => su_user, :su_password => su_password})
+  #
+  # Except that it a yields a block and re-raises certain Net::SSH exceptions as
+  # MiqException objects.
+  #
   def self.shell_with_su(host, remote_user, remote_password, su_user, su_password, options = {})
     options[:su_user], options[:su_password] = su_user, su_password
     ssu = MiqSshUtil.new(host, remote_user, remote_password, options)

--- a/lib/gems/pending/util/MiqSshUtil.rb
+++ b/lib/gems/pending/util/MiqSshUtil.rb
@@ -85,7 +85,7 @@ class MiqSshUtil
   # use the specified +content+ instead of the content of the local file.
   #
   # At least one of the +content+ or +path+ parameters must be specified or
-  # and error is raised.
+  # an error is raised.
   #
   def put_file(to, content = nil, path = nil)
     raise "Need to provide either content or path" if content.nil? && path.nil?
@@ -105,7 +105,7 @@ class MiqSshUtil
   # then the +cmd+ will automatically be prepended with "sudo".
   #
   # If specified, the data collection will stop the first time a +doneStr+
-  # argument is encountered at the end of a line. If practice you would
+  # argument is encountered at the end of a line. In practice you would
   # typically specify a newline character.
   #
   # If present, the +stdin+ argument will be sent to the underlying
@@ -308,7 +308,7 @@ class MiqSshUtil
   # +remote_user+ and +remote_password+ options passed in as the first three
   # params to the constructor, while the +su_user+ and +su_password+ parameters
   # automatically set the corresponding :su_user and :su_password options. The
-  # remaining options are are passed normally.
+  # remaining options are passed normally.
   #
   # This method is functionally identical to the following code, except that it
   # yields itself (and nil) and re-raises certain Net::SSH exceptions as

--- a/lib/gems/pending/util/MiqSshUtil.rb
+++ b/lib/gems/pending/util/MiqSshUtil.rb
@@ -1,5 +1,6 @@
 require 'net/ssh'
 require 'net/sftp'
+require 'tempfile'
 
 class MiqSshUtil
   # The exit status of the ssh command.
@@ -303,12 +304,11 @@ class MiqSshUtil
   # automatically set the :su_user and :su_password options. Remaining options are
   # are passed normally.
   #
-  # This method is functionally identical to:
+  # This method is functionally identical to the following code, except that it
+  # yields itself (and nil) and re-raises certain Net::SSH exceptions as
+  # MiqException objects.
   #
   #   MiqSshUtil.new(host, remote_user, remote_password, {:su_user => su_user, :su_password => su_password})
-  #
-  # Except that it a yields a block and re-raises certain Net::SSH exceptions as
-  # MiqException objects.
   #
   def self.shell_with_su(host, remote_user, remote_password, su_user, su_password, options = {})
     options[:su_user], options[:su_password] = su_user, su_password
@@ -329,7 +329,6 @@ class MiqSshUtil
   end
 
   def fileOpen(file_path, perm = 'r')
-    require 'tempfile'
     if block_given?
       Tempfile.open('miqscvmm') do |tf|
         tf.close

--- a/lib/gems/pending/util/MiqSshUtil.rb
+++ b/lib/gems/pending/util/MiqSshUtil.rb
@@ -68,6 +68,9 @@ class MiqSshUtil
     end
   end # def initialize
 
+  # Download the contents of the remote +from+ file to the local +to+ file. Some
+  # messages will be written to the global ManageIQ log in debug mode.
+  #
   def get_file(from, to)
     run_session do |ssh|
       $log&.debug("MiqSshUtil::get_file - Copying file #{@host}:#{from} to #{to}.")
@@ -87,6 +90,20 @@ class MiqSshUtil
     end
   end
 
+  # Execute the remote +cmd+ via ssh. This is automatically handled via
+  # channels on the ssh session so that various states can be checked,
+  # stored and logged independently and asynchronously.
+  #
+  # If the :passwordless_sudo option was set to true in the constructor
+  # then the +cmd+ will automatically be prepended with "sudo".
+  #
+  # If specified, the data collection will stop the first time a +doneStr+
+  # argument is encountered at the end of a line. If practice you would
+  # typically specify a newline character.
+  #
+  # If present, the +stdin+ argument will be sent to the underlying
+  # command as input for those commands that expect it, e.g. tee.
+  #
   def exec(cmd, doneStr = nil, stdin = nil)
     errBuf = ""
     outBuf = ""
@@ -146,6 +163,15 @@ class MiqSshUtil
     end
   end # def exec
 
+  # Execute the remote +cmd+ via ssh. This is nearly identical to the exec
+  # method, and is used only if the :su_user and :su_password options are
+  # set in the constructor.
+  #
+  # The difference between this method and the exec method are primarily in
+  # the underlying handling of the sudo user and sudo password parameters, i.e
+  # creating a PTY session and dealing with prompts. From the perspective of
+  # an end user they are essentially identical.
+  #
   def suexec(cmd_str, doneStr = nil, stdin = nil)
     errBuf = ""
     outBuf = ""

--- a/lib/gems/pending/util/MiqSshUtil.rb
+++ b/lib/gems/pending/util/MiqSshUtil.rb
@@ -81,6 +81,12 @@ class MiqSshUtil
     end
   end
 
+  # Upload the contents of local file +to+ to remote location +path+. You may
+  # use the specified +content+ instead of the content of the local file.
+  #
+  # At least one of the +content+ or +path+ parameters must be specified or
+  # and error is raised.
+  #
   def put_file(to, content = nil, path = nil)
     raise "Need to provide either content or path" if content.nil? && path.nil?
     run_session do |ssh|
@@ -300,9 +306,9 @@ class MiqSshUtil
 
   # Shortcut method that creates and yields an MiqSshUtil object, with the +host+,
   # +remote_user+ and +remote_password+ options passed in as the first three
-  # params to the constructor, while the +su_user+ and +su_password+ parameters are
-  # automatically set the :su_user and :su_password options. Remaining options are
-  # are passed normally.
+  # params to the constructor, while the +su_user+ and +su_password+ parameters
+  # automatically set the corresponding :su_user and :su_password options. The
+  # remaining options are are passed normally.
   #
   # This method is functionally identical to the following code, except that it
   # yields itself (and nil) and re-raises certain Net::SSH exceptions as


### PR DESCRIPTION
As part of my understanding through documentation process, and in preparation for moving this bit of code into its own gem, I have added documentation to the `MiqSshUtil` class. This code was previously completely undocumented.

There are also a couple very minor code changes. One was to give each `attr_reader` its own line so that they can be documented individually. The other change was to `require 'tempfile'` at the top of the file. Frankly, we were getting lucky we didn't hit a `LoadError` up to this point because it's used within the `temp_cmd_file` method without being required first. So, some other code must have required it earlier.