### PR TITLE
Fix uninitialized warning in vmdb-logger.rb

### DIFF
--- a/lib/gems/pending/util/vmdb-logger.rb
+++ b/lib/gems/pending/util/vmdb-logger.rb
@@ -167,6 +167,8 @@ class VMDBLogger < Logger
     private
 
     def prefix_task_id(msg)
+      $_miq_worker_current_msg ||= nil
+
       # Add task id to the message if a task is currently being worked on.
       if (task_id = (Thread.current["tracking_label"] || $_miq_worker_current_msg.try(:task_id)))
         prefix = "Q-task_id([#{task_id}])"

--- a/spec/util/vmdb-logger_spec.rb
+++ b/spec/util/vmdb-logger_spec.rb
@@ -1,6 +1,6 @@
 require 'util/vmdb-logger'
 
-describe VMDBLogger do
+RSpec.describe VMDBLogger do
   describe "#log_hashes" do
     let(:buffer) { StringIO.new }
     let(:logger) { described_class.new(buffer) }
@@ -95,11 +95,9 @@ b:
   end
 
   context "long messages" do
-    let(:logger) { VMDBLogger.new(@log) }
-
     it "truncates long messages when max_message_size is set" do
       msg = "a" * 1_572_864 # 1.5 mb in bytes
-      _, message = logger.formatter.call(:error, Time.now.utc, "", msg).split("-- : ")
+      _, message = VMDBLogger::Formatter.new.call(:error, Time.now.utc, "", msg).split("-- : ")
       expect(message.strip.size).to eq(1.megabyte)
     end
   end


### PR DESCRIPTION
Currently the core specs are flooded with this warning if rspec warnings are enabled:

`lib/gems/pending/util/vmdb-logger.rb:171: warning: global variable '$_miq_worker_current_msg' not initialized`

This global is set (eventually) by app/models/miq_queue_worker_base/runner.rb (where it is also uninitialized, but nevermind that for now):

https://github.com/ManageIQ/manageiq/blob/master/app/models/miq_queue_worker_base/runner.rb#L101