### PR TITLE
Introduce FirmwareUpdateError

### DIFF
--- a/lib/gems/pending/util/miq-exception.rb
+++ b/lib/gems/pending/util/miq-exception.rb
@@ -46,6 +46,9 @@ module MiqException
   # Exceptions during Provisioning
   class MiqProvisionError < Error; end
 
+  # Exceptions during Firmware Update
+  class MiqFirmwareUpdateError < Error; end
+
 
   class MaintenanceBundleInvalid < Error; end
   class MiqDeploymentError < Error; end


### PR DESCRIPTION
We're implementing a new process, the physical server firmware update, with state machine and everything. And it's best to raise a dedicated error when things go wrong.

@miq-bot add_label enhancement
@miq-bot assign @carbonin 