### PR TITLE
MiqSshUtil updates

### DIFF
--- a/lib/gems/pending/util/MiqSshUtil.rb
+++ b/lib/gems/pending/util/MiqSshUtil.rb
@@ -1,6 +1,7 @@
 require 'net/ssh'
 require 'net/sftp'
 require 'tempfile'
+require 'active_support/core_ext/object/blank'
 
 class MiqSshUtil
   # The exit status of the ssh command.
@@ -150,7 +151,7 @@ class MiqSshUtil
         $log.debug "MiqSshUtil::exec - Command: #{cmd} started." if $log
         channel.exec(cmd) do |chan, success|
           raise "MiqSshUtil::exec - Could not execute command #{cmd}" unless success
-          unless stdin.nil?
+          if stdin.present?
             chan.send_data(stdin)
             chan.eof!
           end

--- a/spec/util/miq_ssh_util_spec.rb
+++ b/spec/util/miq_ssh_util_spec.rb
@@ -1,6 +1,61 @@
 require 'util/MiqSshUtil'
 
-describe MiqSshUtil do
+RSpec.describe MiqSshUtil do
+  let(:hostname) { 'localhost' }
+  let(:username) { 'someuser' }
+  let(:password) { 'xxxxxxxx' }
+
+  let(:ssh_session)  { instance_double(Net::SSH::Connection::Session) }
+  let(:ssh_channel)  { instance_double(Net::SSH::Connection::Channel) }
+  let(:data)    { Net::SSH::Buffer.new([0].pack('N')) }
+
+  let(:ssh_util) { MiqSshUtil.new(hostname, username, password) }
+
+  before do
+    allow(ssh_util).to receive(:run_session).and_yield(ssh_session)
+  end
+
+  def stub_channels
+    allow(ssh_channel).to receive(:on_data).and_yield(ssh_channel, 'some_data')
+    allow(ssh_channel).to receive(:on_request).with('exit-status').and_yield(ssh_channel, data)
+    allow(ssh_channel).to receive(:on_request).with('exit-signal').and_yield(ssh_channel, data)
+    allow(ssh_channel).to receive(:on_eof).and_yield(ssh_channel)
+    allow(ssh_channel).to receive(:on_close).and_yield(ssh_channel)
+    allow(ssh_channel).to receive(:on_extended_data).and_yield(ssh_channel, 1, '')
+  end
+
+  context "#exec" do
+    before do
+      stub_channels
+      allow(ssh_session).to receive(:open_channel).and_yield(ssh_channel)
+      allow(ssh_session).to receive(:loop)
+    end
+
+    it "raises an error if the command is unsuccessful" do
+      allow(ssh_channel).to receive(:exec).and_yield(ssh_channel, false)
+      expect { ssh_util.exec('bogus') }.to raise_error(RuntimeError, /could not execute command/i)
+    end
+
+    it "raises the expected error if a signal is found" do
+      allow(ssh_channel).to receive(:exec).and_yield(ssh_channel, true)
+      allow(data).to receive(:read_string).and_return('KILL')
+      expect { ssh_util.exec('bogus') }.to raise_error(RuntimeError, /exited with signal KILL/i)
+    end
+
+    it "raises the expected error if a status is non-zero and error buffer is empty" do
+      allow(ssh_channel).to receive(:exec).and_yield(ssh_channel, true)
+      allow(data).to receive(:read_long).and_return(127)
+      expect { ssh_util.exec('bogus') }.to raise_error(RuntimeError, /exited with status 127/i)
+    end
+
+    it "raises the expected error if a status is non-zero and error buffer is not empty" do
+      allow(ssh_channel).to receive(:exec).and_yield(ssh_channel, true)
+      allow(ssh_channel).to receive(:on_extended_data).and_yield(ssh_channel, 1, 'invalid')
+      allow(data).to receive(:read_long).and_return(127)
+      expect { ssh_util.exec('bogus') }.to raise_error(RuntimeError, /'bogus' failed: invalid, status: 127/i)
+    end
+  end
+
   context "#temp_cmd_file" do
     before do
       @ssh_util = MiqSshUtil.new("localhost", "temp", "something")


### PR DESCRIPTION
This PR fixes a bug in the `MiqSshUtil#exec` method, and makes a few tweaks to the constructor and exec method in general.

Fixes:

Error handling is currently semi-busted. The `on_extended_data` hook is missing a yield param. The net result is that there is never any data in the error output. In addition, the `status` check could break since it defaults to nil, with the result that it will try to call `.zero?` on a nil object, which will raise an exception. So, I changed the default from nil to 0.

Updates:

* Some unused code that was commented out was removed, i.e. logging.
* Some workaround code for older versions of net-ssh that is no longer relevant was removed.
* You can now configure the `use_agent` option. It still defaults to false for backwards compatibility.
* The error handling was updated slightly. It now no longer relies on activesupport methods, and checks the error buffer, too.

You can see these issues in practice with this simple script:

```
# Assuming you're in the manageiq-gems-pending repo
$:.unshift('lib/gems/pending/util')
require 'MiqSshUtil'
require 'etc'

# Adjust as desired
hostname = 'localhost'
username = Etc.getlogin
password = 'xxxxxxx'
command  = 'bogus'

pubkey = IO.read(File.join(Dir.home, '.ssh', 'id_rsa.pub'))

# You will have to edit MiqSshUtil.rb if you're on master and need 'use_agent'.
opts = {
  :key_data => pubkey,
  :use_agent => true
}

ssh = MiqSshUtil.new(hostname, username, password)

begin
  result = ssh.exec(command)
rescue => err
  puts "OOPS: #{err.message}"
else
  puts "RESULT: #{result}"
end
```

BEFORE:

`RESULT: ` <---- Blank! And not registered as an error!

AFTER:

`OOPS: MiqSshUtil::exec - Command 'bogus' failed: bash: bogus: command not found, status: 127`

Partially addresses https://bugzilla.redhat.com/show_bug.cgi?id=1719689