### PR TITLE
Dup strings in case they're frozen before force_encoding

### DIFF
--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -147,7 +147,7 @@ module REXML
           @value = Text.unnormalize(second.to_s, nil)
         rescue => err
           if err.class == ::Encoding::CompatibilityError
-            second_utf8 = second.to_s.force_encoding('UTF-8').encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '')
+            second_utf8 = second.to_s.dup.force_encoding('UTF-8').encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '')
             @value = Text.unnormalize(second_utf8)
           else
             $log.error "Encoding error: #{second_utf8}" if $log

--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -228,7 +228,7 @@ module REXML
 
     alias_method :add_attribute_orig, :add_attribute
     def add_attribute(key, value)
-      value_utf8 = value.to_s.force_encoding('UTF-8').encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '') unless value.nil?
+      value_utf8 = value.to_s.dup.force_encoding('UTF-8').encode('UTF-8', :invalid => :replace, :undef => :replace, :replace => '') unless value.nil?
       add_attribute_orig(key.to_s, value_utf8) unless value_utf8.nil?
     end
 


### PR DESCRIPTION
Calling `force_encoding` on a frozen string will bomb. This dups the string first before calling it.

This was already being done at https://github.com/ManageIQ/manageiq-gems-pending/blob/master/lib/gems/pending/util/xml/miq_rexml.rb#L288.

BZ: https://bugzilla.redhat.com/show_bug.cgi?id=1535782