### PR TITLE
[MiqGenericMountSession] Fix .source_for_log

### DIFF
--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -490,6 +490,12 @@ class MiqGenericMountSession < MiqFileStorage::Interface
   end
 
   def source_for_log
-    @input_writer ? "<STREAMED_FROM_CMD>" : @source_input.path
+    if @input_writer
+      "<STREAMED_FROM_CMD>"
+    elsif @source_input
+      @source_input.path
+    else
+      "<NOT_READY>"
+    end
   end
 end


### PR DESCRIPTION
Does better fallback handling and nil checking for this method.

This can fail as part of `MiqGenericMountSession#add`'s `rescue` statement when the `@source_input` is not defined, and that will mask the actual error that was raised.

This fixes that bug so the proper error is shown in the logs.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1763890