### PR TITLE
Require 'erubis'

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "aws-sdk-s3",              "~> 1.0"
   s.add_runtime_dependency "binary_struct",           "~> 2.1"
   s.add_runtime_dependency "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
+  s.add_runtime_dependency "erubis",                  "= 2.7.0"
   s.add_runtime_dependency "fog-openstack",           "~> 0.3"
   s.add_runtime_dependency "linux_admin",             "~> 1.0"
   s.add_runtime_dependency "manageiq-password",       "~> 0.3"


### PR DESCRIPTION
Travis is failing in ivanchuk branch (master will be red too once cron job runs)

/home/travis/build/ManageIQ/manageiq-gems-pending/vendor/bundle/ruby/2.5.0/gems/winrm-elevated-1.0.1/lib/winrm/shells/elevated.rb:17:in `require': cannot load such file -- erubis (LoadError)

https://travis-ci.org/ManageIQ/manageiq-gems-pending/builds/607639054

`winrm-elevated` doesn't list `erubis` as a requirement, and the gem was being pulled in from `winrm` and `winrm-fs`. New version was released for those 2 gems today and they no longer require `erubis` so no one is providing the gem now.

Adding it here as a workaround. 2.7.0 was the last version released and what we're using.