### PR TITLE
List dependency on handsoap from rubygems.manageiq.org

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,7 +1,5 @@
+source 'http://rubygems.manageiq.org'
 source 'https://rubygems.org'
 
 # Specify your gem's dependencies in manageiq-gems-pending.gemspec
 gemspec
-
-# Modified gems (forked on github)
-gem "handsoap", "~>0.2.5", :require => false, :git => "https://github.com/ManageIQ/handsoap.git", :tag => "v0.2.5-5"

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
   s.add_runtime_dependency "erubis",                  "= 2.7.0"
   s.add_runtime_dependency "fog-openstack",           "~> 0.3"
+  s.add_runtime_dependency "handsoap",                "=  0.2.5.5"
   s.add_runtime_dependency "linux_admin",             "~> 2.0"
   s.add_runtime_dependency "manageiq-password",       "~> 0.3"
   s.add_runtime_dependency "mime-types",              "~> 3.0"


### PR DESCRIPTION
Gems published using: https://github.com/ManageIQ/manageiq-release/pull/103