### PR TITLE
Mark as pending on MacOS when /proc is not accessible

### DIFF
--- a/spec/util/miq-process_spec.rb
+++ b/spec/util/miq-process_spec.rb
@@ -13,6 +13,13 @@ describe MiqProcess do
     end
 
     it "normal case" do
+      if RbConfig::CONFIG['host_os'] =~ /darwin/
+        begin
+          Sys::ProcTable.ps(Process.pid)
+        rescue Errno::ENOENT
+          pending "fails on MacOS due to absence of /proc"
+        end
+      end
       expect(described_class.command_line(Process.pid)).not_to be_empty
     end
   end


### PR DESCRIPTION
specs cannot be run locally on a Mac without the following failure, unless the specs are run as root.

@djberg96 Please review.

I wasn't sure if this was the right way to get around this, or if it was better to make a change to sys-proctable itself.

I'm also not sure if `.command_line` is expected to blow up on a Mac and wonder if we should put this verification there instead of in the spec?

The error you see for this spec without this change is:

```
  1) MiqProcess.command_line normal case
     Failure/Error: Sys::ProcTable.ps(pid).try(:cmdline) || ""

     Errno::ENOENT:
       No such file or directory @ dir_initialize - /proc
     # /Users/jfrey/.gem/ruby/2.5.7/gems/sys-proctable-1.1.5-universal-aix-5/lib/aix/sys/proctable.rb:213:in `open'
     # /Users/jfrey/.gem/ruby/2.5.7/gems/sys-proctable-1.1.5-universal-aix-5/lib/aix/sys/proctable.rb:213:in `foreach'
     # /Users/jfrey/.gem/ruby/2.5.7/gems/sys-proctable-1.1.5-universal-aix-5/lib/aix/sys/proctable.rb:213:in `ps'
     # ./lib/gems/pending/util/miq-process.rb:133:in `command_line'
     # ./spec/util/miq-process_spec.rb:16:in `block (3 levels) in <top (required)>'
```