### PR TITLE
Update sys-proctable gem to 1.2.x

### DIFF
--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -111,7 +111,7 @@ class MiqProcess
       percent_cpu                    = (1.0 * result[:cpu_time]) / cpu_total
       result[:percent_cpu]           = round_to(percent_cpu * 100.0, 2)
 
-      smaps = Sys::ProcTable.ps(pid).smaps
+      smaps = Sys::ProcTable.ps(:pid => pid).smaps
       result[:proportional_set_size] = smaps.pss
       result[:unique_set_size]       = smaps.uss
     when :macosx
@@ -130,7 +130,7 @@ class MiqProcess
   def self.command_line(pid)
     # Already exited pids, or permission errors cause ps or ps.cmdline to be nil,
     # so the best we can do is return an empty string.
-    Sys::ProcTable.ps(pid).try(:cmdline) || ""
+    Sys::ProcTable.ps(:pid => pid).try(:cmdline) || ""
   end
 
   def self.alive?(pid)

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -38,7 +38,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-ssh",                 "~> 4.2.0"
   s.add_runtime_dependency "nokogiri",                "~> 1.8.1"
   s.add_runtime_dependency "rake",                    ">= 11.0"
-  s.add_runtime_dependency "sys-proctable",           "~> 1.1.5"
+  s.add_runtime_dependency "sys-proctable",           "~> 1.2.2"
   s.add_runtime_dependency "sys-uname",               "~> 1.0.1"
   s.add_runtime_dependency "uuidtools",               "~> 2.1.3"
   s.add_runtime_dependency "winrm",                   "~> 2.1"


### PR DESCRIPTION
Update the sys-proctable gem to 1.2.x, which eliminates the platform-specific gems, and thus avoids the bundler issues that plagued it.

It also includes some efficiency updates for Mac from our very own @NickLaMuro. :)

The 1.2.x release switched to use keyword arguments, so a couple minor updates are needed to go along with it.

Related PR: https://github.com/ManageIQ/manageiq/pull/19767

Cross repo tests: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/64