### PR TITLE
[MiqException] Remove custom mount exceptions

### DIFF
--- a/lib/gems/pending/util/miq-exception.rb
+++ b/lib/gems/pending/util/miq-exception.rb
@@ -73,7 +73,6 @@ module MiqException
   class ServiceNotAvailable < Error; end
 
   # MiqGenericMountSession Errors
-  class MountPointAlreadyExists < Error; end
   class MiqLogFileNoSuchFileOrDirectory < Error; end
 
   class MiqDatabaseBackupInsufficientSpace < Error; end

--- a/lib/gems/pending/util/miq-exception.rb
+++ b/lib/gems/pending/util/miq-exception.rb
@@ -74,7 +74,6 @@ module MiqException
 
   # MiqGenericMountSession Errors
   class MountPointAlreadyExists < Error; end
-  class MiqLogFileMountPointMissing < Error; end
   class MiqLogFileNoSuchFileOrDirectory < Error; end
 
   class MiqDatabaseBackupInsufficientSpace < Error; end

--- a/lib/gems/pending/util/miq-exception.rb
+++ b/lib/gems/pending/util/miq-exception.rb
@@ -72,9 +72,6 @@ module MiqException
   # Openstack connection error when service is not available
   class ServiceNotAvailable < Error; end
 
-  # MiqGenericMountSession Errors
-  class MiqLogFileNoSuchFileOrDirectory < Error; end
-
   class MiqDatabaseBackupInsufficientSpace < Error; end
 
   class RbacPrivilegeException < Error; end

--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -14,6 +14,8 @@ class MiqGenericMountSession < MiqFileStorage::Interface
   require 'util/mount/miq_smb_session'
   require 'util/mount/miq_glusterfs_session'
 
+  class NoSuchFileOrDirectory < RuntimeError; end
+
   attr_accessor :settings, :mnt_point, :logger
 
   def initialize(log_settings)
@@ -144,7 +146,7 @@ class MiqGenericMountSession < MiqFileStorage::Interface
     rescue => err
       if err.kind_of?(RuntimeError) && err.message =~ /No such file or directory/
         msg = "No such file or directory when connecting to host: [#{@host}] share: [#{@mount_path}]"
-        raise MiqException::MiqLogFileNoSuchFileOrDirectory, msg
+        raise NoSuchFileOrDirectory, msg
       end
       msg = "Connecting to host: [#{@host}], share: [#{@mount_path}] encountered error: [#{err.class.name}] [#{err.message}]"
       logger.error("#{log_header} #{msg}...#{err.backtrace.join("\n")}")
@@ -355,7 +357,7 @@ class MiqGenericMountSession < MiqFileStorage::Interface
       logger.info("#{log_header} Deleting [#{relpath}] on [#{log_uri}]...")
       FileUtils.rm_rf(relpath)
       logger.info("#{log_header} Deleting [#{relpath}] on [#{log_uri}]...complete")
-    rescue MiqException::MiqLogFileNoSuchFileOrDirectory => err
+    rescue NoSuchFileOrDirectory => err
       logger.warn("#{log_header} No such file or directory to delete: [#{log_uri}]")
     rescue => err
       msg = "Deleting [#{relpath}] on [#{log_uri}], failed due to err '#{err.message}'"

--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -141,10 +141,6 @@ class MiqGenericMountSession < MiqFileStorage::Interface
       raise "Connect: Cannot communicate with: #{@host} - verify the URI host value and your DNS settings" unless self.pingable?
 
       mount_share
-    rescue MiqException::MiqLogFileMountPointMissing => err
-      logger.warn("#{log_header} Connecting to host: [#{@host}], share: [#{@mount_path}] encountered error: [#{err.class.name}] [#{err.message}]...retrying after disconnect")
-      disconnect
-      retry
     rescue => err
       if err.kind_of?(RuntimeError) && err.message =~ /No such file or directory/
         msg = "No such file or directory when connecting to host: [#{@host}] share: [#{@mount_path}]"


### PR DESCRIPTION
Removes exceptions related to mounting that are either dead code or only used within this repo.

See individual commits for info about each removal.

Links
-----
- `MountPointAlreadyExists` search results:  https://github.com/search?q=org%3AManageIQ+MountPointAlreadyExists&type=Code
- `MiqLogFileMountPointMissing` search results:  https://github.com/search?q=org%3AManageIQ+MiqLogFileMountPointMissing&type=Code
- `MiqLogFileNoSuchFileOrDirectory` search results:  https://github.com/search?q=org%3AManageIQ+MiqLogFileNoSuchFileOrDirectory&type=Code