### PR TITLE
Refactor MiqProcess

### DIFF
--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -130,15 +130,6 @@ class MiqProcess
     Sys::ProcTable.ps(:pid => pid).try(:cmdline) || ""
   end
 
-  # Return whether or not the given +pid+ is running.
-  #
-  def self.alive?(pid)
-    Process.kill(0, pid)
-    true
-  rescue Errno::ESRCH
-    false
-  end
-
   def self.is_worker?(pid)
     command_line = self.command_line(pid)
     command_line.include?(MiqWorker::PROCESS_TITLE_PREFIX)
@@ -230,29 +221,5 @@ class MiqProcess
     # Convert format 00:00:00 to seconds
     t = time_str.split(':')
     (t[0].to_i * 3600) + (t[1].to_i * 60) + t[2].to_i
-  end
-
-  # Suspend the process +pid+ using a SIGSTOP. If the process isn't running
-  # then this is no-op.
-  #
-  def self.suspend_process(pid)
-    case Sys::Platform::OS
-    when :unix
-      Process.kill('STOP', pid) if alive?(pid)
-    else
-      raise "Method MiqProcess.suspend_process not implemented on this platform [#{Sys::Platform::IMPL}]"
-    end
-  end
-
-  # Resume the process +pid+ using a SIGCONT. If the process isn't running
-  # then this is a no-op.
-  #
-  def self.resume_process(pid)
-    case Sys::Platform::OS
-    when :unix
-      Process.kill('CONT', pid) if alive?(pid)
-    else
-      raise "Method MiqProcess.resume_process not implemented on this platform [#{Sys::Platform::IMPL}]"
-    end
   end
 end

--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -232,23 +232,25 @@ class MiqProcess
     (t[0].to_i * 3600) + (t[1].to_i * 60) + t[2].to_i
   end
 
-  # Suspend the process +pid+ using a SIGSTOP.
+  # Suspend the process +pid+ using a SIGSTOP. If the process isn't running
+  # then this is no-op.
   #
   def self.suspend_process(pid)
     case Sys::Platform::OS
     when :unix
-      Process.kill('STOP', pid)
+      Process.kill('STOP', pid) if alive?(pid)
     else
       raise "Method MiqProcess.suspend_process not implemented on this platform [#{Sys::Platform::IMPL}]"
     end
   end
 
-  # Resume the process +pid+ using a SIGCONT.
+  # Resume the process +pid+ using a SIGCONT. If the process isn't running
+  # then this is a no-op.
   #
   def self.resume_process(pid)
     case Sys::Platform::OS
     when :unix
-      Process.kill('CONT', pid)
+      Process.kill('CONT', pid) if alive?(pid)
     else
       raise "Method MiqProcess.resume_process not implemented on this platform [#{Sys::Platform::IMPL}]"
     end

--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -119,21 +119,23 @@ class MiqProcess
     result
   end
 
+  # Return the command line string for the given +pid+. If the pid has already
+  # exited, or there is some sort of permissions issue that causes it to be set
+  # to nil, then return an empty string instead.
+  #
   def self.command_line(pid)
     # Already exited pids, or permission errors cause ps or ps.cmdline to be nil,
     # so the best we can do is return an empty string.
     Sys::ProcTable.ps(:pid => pid).try(:cmdline) || ""
   end
 
+  # Return whether or not the given +pid+ is running.
+  #
   def self.alive?(pid)
-    raise NotImplementedError, "Method MiqProcess.alive? not implemented on this platform [#{Sys::Platform::IMPL}]" unless Sys::Platform::OS == :unix
-
-    begin
-      Process.kill(0, pid)
-      true
-    rescue Errno::ESRCH
-      false
-    end
+    Process.kill(0, pid)
+    true
+  rescue Errno::ESRCH
+    false
   end
 
   def self.is_worker?(pid)

--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -96,13 +96,13 @@ class MiqProcess
       result[:memory_usage]          = x[:rss] * 4096
       result[:memory_size]           = x[:vsize]
       percent_memory                 = (1.0 * result[:memory_usage]) / MiqSystem.total_memory
-      result[:percent_memory]        = round_to(percent_memory * 100.0, 2)
+      result[:percent_memory]        = percent_memory.round(2)
       result[:cpu_time]              = x[:stime] + x[:utime]
       cpu_status                     = MiqSystem.status[:cpu]
       cpu_total                      = (0..3).inject(0) { |sum, x| sum + cpu_status[x].to_i }
       cpu_total                     /= MiqSystem.num_cpus
       percent_cpu                    = (1.0 * result[:cpu_time]) / cpu_total
-      result[:percent_cpu]           = round_to(percent_cpu * 100.0, 2)
+      result[:percent_cpu]           = percent_cpu.round(2)
 
       smaps = Sys::ProcTable.ps(:pid => pid).smaps
       result[:proportional_set_size] = smaps.pss
@@ -254,10 +254,5 @@ class MiqProcess
     else
       raise "Method MiqProcess.resume_process not implemented on this platform [#{Sys::Platform::IMPL}]"
     end
-  end
-
-  def self.round_to(number, precision)
-    mult = 10**precision
-    (number * mult).round.to_f / mult
   end
 end

--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -10,7 +10,8 @@ class MiqProcess
   # +process_name+ or +process_name.exe+.
   #
   def self.get_active_process_by_name(process_name)
-    Sys::ProcTable.ps.select{ |process| [process_name, "#{process_name}.exe"].include?(process.name) }.map(&:pid)
+    procs = Sys::ProcTable.ps(:smaps => false, :cgroup => false)
+    procs.select { |process| [process_name, "#{process_name}.exe"].include?(process.name) }.map(&:pid)
   end
 
   def self.linux_process_stat(pid = nil)

--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -231,17 +231,23 @@ class MiqProcess
     (t[0].to_i * 3600) + (t[1].to_i * 60) + t[2].to_i
   end
 
+  # Suspend the process +pid+ using a SIGSTOP.
+  #
   def self.suspend_process(pid)
     case Sys::Platform::OS
-    when :windows then Process.process_thread_list[pid].each { |tid| Process.suspend_resume_thread(tid, false) }
+    when :unix
+      Process.kill('STOP', pid)
     else
       raise "Method MiqProcess.suspend_process not implemented on this platform [#{Sys::Platform::IMPL}]"
     end
   end
 
+  # Resume the process +pid+ using a SIGCONT.
+  #
   def self.resume_process(pid)
     case Sys::Platform::OS
-    when :windows then Process.process_thread_list[pid].each { |tid| Process.suspend_resume_thread(tid, true) }
+    when :unix
+      Process.kill('CONT', pid)
     else
       raise "Method MiqProcess.resume_process not implemented on this platform [#{Sys::Platform::IMPL}]"
     end
@@ -252,10 +258,3 @@ class MiqProcess
     (number * mult).round.to_f / mult
   end
 end
-
-# Examples:
-# puts MiqProcess.processInfo().inspect
-# puts MiqProcess.process_list_all().inspect
-# MiqProcess.process_list_all().each_pair do |k,v|
-#  puts v.inspect
-# end

--- a/spec/util/miq-process_spec.rb
+++ b/spec/util/miq-process_spec.rb
@@ -16,4 +16,30 @@ describe MiqProcess do
       expect(described_class.command_line(Process.pid)).not_to be_empty
     end
   end
+
+  context ".get_active_process_by_name" do
+    before do
+      proc_list = [
+        double("ProcessStruct", :name => "gvim", :pid => 101),
+        double("ProcessStruct", :name => "ruby", :pid => 201),
+        double("ProcessStruct", :name => "ruby", :pid => 202),
+        double("ProcessStruct", :name => "notepad.exe", :pid => 301)
+      ]
+      allow(Sys::ProcTable).to receive(:ps).and_return(proc_list)
+    end
+
+    it "returns the expected processes if found" do
+      expect(described_class.get_active_process_by_name('gvim')).to eql([101])
+      expect(described_class.get_active_process_by_name('ruby')).to eql([201, 202])
+    end
+
+    it "returns an empty array if not found" do
+      expect(described_class.get_active_process_by_name('bogus')).to eql([])
+    end
+
+    it "finds the name even without an .exe extension" do
+      expect(described_class.get_active_process_by_name('notepad')).to eql([301])
+      expect(described_class.get_active_process_by_name('notepad.exe')).to eql([301])
+    end
+  end
 end


### PR DESCRIPTION
Some initial refactorings based on https://github.com/ManageIQ/manageiq-gems-pending/issues/459. Specifically:

* Simplified the `get_active_process_by_name` method to a ~~one~~ two liner using the sys-proctable gem.
~~* Updated the `alive?` method, the code is already cross-platform.~~
~~* Updated the `suspend_process` and `resume_process` methods. Removed the dead Windows code, added an implementation for unixy platforms.~~
* Remove the `round_to` method, just use `Float#round`.

I also added and updated some comments.

Update: The `pause`, `resume` and `alive?` methods were moved into the `Process` module in the `more_core_extensions` library.