### PR TITLE
Update nokogiri version to 1.10.8

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-scp",                 "~> 1.2.1"
   s.add_runtime_dependency "net-sftp",                "~> 2.1.2"
   s.add_runtime_dependency "net-ssh",                 "~> 4.2.0"
-  s.add_runtime_dependency "nokogiri",                "~> 1.8.1"
+  s.add_runtime_dependency "nokogiri",                "~> 1.10.8"
   s.add_runtime_dependency "rake",                    ">= 11.0"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.2"
   s.add_runtime_dependency "sys-uname",               "~> 1.0.1"


### PR DESCRIPTION
There was a CVE for libxml:

https://nvd.nist.gov/vuln/detail/CVE-2020-7595

Addressed in nokogiri 1.10.8:

https://github.com/sparklemotion/nokogiri/blob/master/CHANGELOG.md#security