### PR TITLE
Removing deprecated Gemnasium badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,6 @@
 [![Build Status](https://travis-ci.org/ManageIQ/manageiq-gems-pending.svg?branch=master)](https://travis-ci.org/ManageIQ/manageiq-gems-pending)
 [![Code Climate](https://codeclimate.com/github/ManageIQ/manageiq-gems-pending.svg)](https://codeclimate.com/github/ManageIQ/manageiq-gems-pending)
 [![Test Coverage](https://codeclimate.com/github/ManageIQ/manageiq-gems-pending/badges/coverage.svg)](https://codeclimate.com/github/ManageIQ/manageiq-gems-pending/coverage)
-[![Dependency Status](https://gemnasium.com/ManageIQ/manageiq-gems-pending.svg)](https://gemnasium.com/ManageIQ/manageiq-gems-pending)
 
 Code extracted from ManageIQ/manageiq gems/pending directory in an effort to reduce complexity of ManageIQ/manageiq repository.
 


### PR DESCRIPTION
Functionality has been replaced by GitHub's dependency graph and security alerts.