### PR TITLE
maintain consistent versioning of fog openstack across repos

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "binary_struct",           "~> 2.1"
   s.add_runtime_dependency "bundler",                 ">= 1.8.4" # rails-assets requires bundler >= 1.8.4, see: https://rails-assets.org/
   s.add_runtime_dependency "erubis",                  "= 2.7.0"
-  s.add_runtime_dependency "fog-openstack",           "~> 0.3"
+  s.add_runtime_dependency "fog-openstack",           "~> 0.3.10"
   s.add_runtime_dependency "handsoap",                "=  0.2.5.5"
   s.add_runtime_dependency "linux_admin",             "~> 2.0"
   s.add_runtime_dependency "manageiq-password",       "~> 0.3"


### PR DESCRIPTION
I feel like we should be consistent as well here: 

```
 manageiq-providers-openstack was resolved to 0.1.0, which depends on
      fog-openstack (>= 0.3.10)
```