### PR TITLE
Use Etc for num_cpus

### DIFF
--- a/lib/gems/pending/util/miq-system.rb
+++ b/lib/gems/pending/util/miq-system.rb
@@ -45,9 +45,12 @@ class MiqSystem
     nil
   end
 
+  # Returns the number of logical processors on the system.
+  #
   def self.num_cpus
     require 'etc'
-    Etc.nprocessors
+    # cache it since it won't change during a process lifetime
+    @num_cpus ||= Etc.nprocessors
   end
 
   def self.memory

--- a/lib/gems/pending/util/miq-system.rb
+++ b/lib/gems/pending/util/miq-system.rb
@@ -46,9 +46,8 @@ class MiqSystem
   end
 
   def self.num_cpus
-    return unless Sys::Platform::IMPL == :linux
-    require 'linux_admin'
-    @num_cpus ||= LinuxAdmin::Hardware.new.total_cores
+    require 'etc'
+    Etc.nprocessors
   end
 
   def self.memory


### PR DESCRIPTION
For the `MiqSystem#num_cpus` method, just use the` Etc.nprocessors` method since:

* It's in the stdlib (and this method has been available since Ruby 2.2)
* It's cross-platform
* It's less code