### PR TITLE
Remove circular require from xml_hash.rb

### DIFF
--- a/lib/gems/pending/util/xml/xml_hash.rb
+++ b/lib/gems/pending/util/xml/xml_hash.rb
@@ -1,6 +1,5 @@
 require 'enumerator'
 require 'rexml/document'
-require 'util/xml/xml_utils'
 
 module XmlHash
   class Element < Hash

--- a/lib/gems/pending/util/xml/xml_hash.rb
+++ b/lib/gems/pending/util/xml/xml_hash.rb
@@ -1,5 +1,6 @@
 require 'enumerator'
 require 'rexml/document'
+require 'active_support/core_ext/hash/keys'
 
 module XmlHash
   class Element < Hash
@@ -162,7 +163,7 @@ module XmlHash
       hash = {} if hash.nil?
 
       each do |c|
-        e = (hash[options[:symbols] == false ? c.name.to_s : c.name] ||= []) << (options[:symbols] == false ? XmlHelpers.stringify_keys(c.attributes) : c.attributes)
+        e = (hash[options[:symbols] == false ? c.name.to_s : c.name] ||= []) << (options[:symbols] == false ? c.attributes&.stringify_keys : c.attributes)
         e.last[options[:symbols] == false ? 'content' : :content] = c.text if c.text
         c.to_h_simple(options, e.last)
       end


### PR DESCRIPTION
Currently there's a circular require caused by xml_hash.rb. The circle is:

* xml_utils.rb -> `require 'util/miq-xml'`
* miq-xml.rb -> `require 'util/xml/miq_rexml'`
* miq_rexml.rb -> `require 'util/xml/xml_hash'`
* xml_hash.rb -> `require 'util/xml/xml_utils'`

The xml_utils.rb file provides 4 classes: `XmlFind`, `XmlHelpers`, `Xml2tags`, and `Xml2Array`. The xml_hash.rb file is only using one method from one of these classes: `XmlHelpers.stringify_keys`. Since activesupport has an extension that does this, I've replaced that code with the activesupport code (and activesupport is already a dependency).

The circular dependency manifests itself in the manageiq-smartstate specs, which I've posted about at https://github.com/ManageIQ/manageiq-smartstate/issues/131.