### PR TITLE
Remove miq-kernel.rb / require_relative

### DIFF
--- a/lib/gems/pending/util/extensions/miq-kernel.rb
+++ b/lib/gems/pending/util/extensions/miq-kernel.rb
@@ -1,7 +1,0 @@
-module Kernel
-  # Replaces Kernel's require_relative to allow it to be used in irb and eval
-  # See: http://bugs.ruby-lang.org/issues/4487
-  def require_relative(path)
-    require File.join(File.dirname(caller[0]), path.to_str)
-  end
-end

--- a/spec/util/extensions/miq-kernel_spec.rb
+++ b/spec/util/extensions/miq-kernel_spec.rb
@@ -1,7 +1,0 @@
-require 'util/extensions/miq-kernel'
-
-describe Kernel do
-  it ".require_relative" do
-    expect(Kernel.respond_to?(:require_relative)).to be_truthy
-  end
-end


### PR DESCRIPTION
The original issue mentioned in http://bugs.ruby-lang.org/issues/4487 appears to be fixed:

```
>cat eval_me1.rb 
eval(File.read('eval_me2.rb'), binding, File.expand_path('./eval_me2.rb'))

>cat eval_me2.rb 
require_relative 'eval_me1.rb'

>ruby eval_me2.rb # nothing
>ruby eval_me1.rb # nothing
```

I also tried loading them in irb:

```
irb(main):001:0> load "eval_me1.rb"
=> true
irb(main):002:0> load "eval_me2.rb"
=> true
```

I tried with both 2.5.7 and 2.6.5.

Part of the cleanup from https://github.com/ManageIQ/manageiq-gems-pending/issues/231