### PR TITLE
Remove circular from miq_rexml.rb

### DIFF
--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -278,7 +278,7 @@ module REXML
     end
 
     def validate_attrs(hash)
-      return nil if h.nil?
+      return nil if hash.nil?
       hash.each_with_object({}) { |(k, v), h| h[k.to_s] = remove_invalid_chars(v.to_s.encode('UTF-8', :undef => :replace, :invalid => :replace, :replace => '')) }
     end
   end

--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -277,9 +277,9 @@ module REXML
       end.join
     end
 
-    def validate_attrs(h)
+    def validate_attrs(hash)
       return nil if h.nil?
-      h.each_with_object({}) { |(k, v), h| h[k.to_s] = remove_invalid_chars(v.to_s.encode('UTF-8', :undef => :replace, :invalid => :replace, :replace => '')) }
+      hash.each_with_object({}) { |(k, v), h| h[k.to_s] = remove_invalid_chars(v.to_s.encode('UTF-8', :undef => :replace, :invalid => :replace, :replace => '')) }
     end
   end
 


### PR DESCRIPTION
Followup to https://github.com/ManageIQ/manageiq-gems-pending/pull/477, this time the circle is:

* xml/xml_utils requires `miq-xml`
* miq-xml requires `xml/miq_rexml`
* xml/miq_rexml requires `xml/xml_utils` (see first bullet)

The miq_rexml.rb file is only using the `XmlHelpers.validate_attrs` method, which is internally two separate methods. Since I do not know of an activesupport method that quite does what these methods do, I simply copied them directly into the miq_rexml.rb file, and removed the circular require.
