### PR TITLE
Deprecate #to_miq_a

### DIFF
--- a/lib/gems/pending/util/extensions/miq-array.rb
+++ b/lib/gems/pending/util/extensions/miq-array.rb
@@ -11,8 +11,8 @@ end
 
 class String
   def to_miq_a
-    ActiveSupport::Deprecation.warn("String#to_miq_a should be replaced by String#lines.to_a", caller.drop(0))
-    lines.to_a
+    ActiveSupport::Deprecation.warn("String#to_miq_a should be replaced by String#lines", caller.drop(0))
+    lines
   end
 end
 

--- a/lib/gems/pending/util/extensions/miq-array.rb
+++ b/lib/gems/pending/util/extensions/miq-array.rb
@@ -1,14 +1,17 @@
 require 'more_core_extensions/core_ext/array'
 require 'active_support/core_ext/array/wrap'
+require 'active_support/deprecation'
 
 class Object #:nodoc:
   def to_miq_a
+    ActiveSupport::Deprecation.warn("Object#to_miq_a should be replaced by Array.wrap", caller.drop(0))
     Array.wrap(self)
   end
 end
 
 class String
   def to_miq_a
+    ActiveSupport::Deprecation.warn("String#to_miq_a should be replaced by String#lines.to_a", caller.drop(0))
     lines.to_a
   end
 end

--- a/spec/util/extensions/miq-array_spec.rb
+++ b/spec/util/extensions/miq-array_spec.rb
@@ -2,15 +2,19 @@ require 'util/extensions/miq-array'
 
 describe NilClass do
   it '#to_miq_a' do
-    expect(nil.to_miq_a).to eq([])
-    expect(nil.to_miq_a).to eq(Array.wrap(nil))
+    ActiveSupport::Deprecation.silence do
+      expect(nil.to_miq_a).to eq([])
+      expect(nil.to_miq_a).to eq(Array.wrap(nil))
+    end
   end
 end
 
 describe Hash do
   it '#to_miq_a' do
-    expect({}.to_miq_a).to eq([{}])
-    expect({}.to_miq_a).to eq(Array.wrap({}))
+    ActiveSupport::Deprecation.silence do
+      expect({}.to_miq_a).to eq([{}])
+      expect({}.to_miq_a).to eq(Array.wrap({}))
+    end
   end
 end
 
@@ -18,26 +22,28 @@ describe String do
   context "#to_miq_a" do
     it 'normal' do
       # NOTE: this differs from Array.wrap
-      expect("onetwo".to_miq_a).to eq(["onetwo"])
+      ActiveSupport::Deprecation.silence { expect("onetwo".to_miq_a).to eq(["onetwo"]) }
     end
 
     it 'with an empty string' do
       # NOTE: this differs from Array.wrap
-      expect("".to_miq_a).to eq([])
+      ActiveSupport::Deprecation.silence { expect("".to_miq_a).to eq([]) }
     end
 
     it 'with newlines' do
       # NOTE: this differs from Array.wrap
-      expect("one\ntwo".to_miq_a).to eq(["one\n", "two"])
+      ActiveSupport::Deprecation.silence { expect("one\ntwo".to_miq_a).to eq(["one\n", "two"]) }
     end
   end
 end
 
 describe Array do
   it "#to_miq_a" do
-    expect([].to_miq_a).to eq([])
-    expect([[]].to_miq_a).to eq([[]])
-    expect([].to_miq_a).to eq(Array.wrap([]))
-    expect([[]].to_miq_a).to eq(Array.wrap([[]]))
+    ActiveSupport::Deprecation.silence do
+      expect([].to_miq_a).to eq([])
+      expect([[]].to_miq_a).to eq([[]])
+      expect([].to_miq_a).to eq(Array.wrap([]))
+      expect([[]].to_miq_a).to eq(Array.wrap([[]]))
+    end
   end
 end


### PR DESCRIPTION
Part of #231 

Dependencies:
- [x] https://github.com/ManageIQ/manageiq/pull/20379
- [X] https://github.com/ManageIQ/manageiq-providers-vmware/pull/602
- [X] https://github.com/ManageIQ/manageiq-ui-classic/pull/7213
- [X] https://github.com/ManageIQ/manageiq/pull/20359