### PR TITLE
cleanup travis.yml

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,4 @@
 ---
-sudo: required
-dist: xenial
 cache: bundler
 language: ruby
 rvm:


### PR DESCRIPTION
per https://blog.travis-ci.com/2018-11-19-required-linux-infrastructure-migration: `If you currently specify sudo: false in your .travis.yml, we recommend removing that configuration soon...` and listing the distro on this repo isn’t necessary and Jason says we should only do so when it’s required which is probably also not here