### PR TITLE
Drop dependency on activerecord since nothing here requires it.

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -20,7 +20,6 @@ Gem::Specification.new do |s|
 
   s.required_ruby_version = "> 2.4"
 
-  s.add_runtime_dependency "activerecord",            "< 5.3"
   s.add_runtime_dependency "activesupport",           "< 5.3"
   s.add_runtime_dependency "awesome_spawn",           "~> 1.5"
   s.add_runtime_dependency "aws-sdk-s3",              "~> 1.0"


### PR DESCRIPTION
I only see it referenced in documentation. https://github.com/ManageIQ/manageiq-gems-pending/search?q=activerecord