### PR TITLE
remove deprecated codeclimate test reporter gem

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -7,4 +7,9 @@ rvm:
 addons:
   postgresql: '10'
 before_install: gem install bundler -v 1.12.5
-after_script: bundle exec codeclimate-test-reporter
+before_script:
+- curl -L https://codeclimate.com/downloads/test-reporter/test-reporter-latest-linux-amd64 > ./cc-test-reporter
+- chmod +x ./cc-test-reporter
+- ./cc-test-reporter before-build
+after_script:
+- ./cc-test-reporter after-build --exit-code $TRAVIS_TEST_RESULT

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -43,7 +43,6 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "winrm",                   "~> 2.1"
   s.add_runtime_dependency "winrm-elevated",          "~> 1.0.1"
 
-  s.add_development_dependency "codeclimate-test-reporter", "~> 1.0.0"
   s.add_development_dependency "ftpd",                      "~> 2.1.0"
   s.add_development_dependency "manageiq-style"
   s.add_development_dependency "pg"


### PR DESCRIPTION
```
Post-install message from codeclimate-test-reporter:

  Code Climate's codeclimate-test-reporter gem has been deprecated in favor of
  our language-agnostic unified test reporter. The new test reporter is faster,
  distributed as a static binary so dependency conflicts never occur, and
  supports parallelized CI builds & multi-language CI configurations.

  Please visit https://docs.codeclimate.com/v1.0/docs/configuring-test-coverage
  for help setting up your CI process with our new test reporter.
```

the token re: https://github.com/ManageIQ/azure-armrest/pull/403#issuecomment-754050779 got added last week

@miq-bot add_label dependencies, test 
@miq-bot assign @Fryguy 



<sub><sup> 173/365 = 0.4740 </sub></sup>