### PR TITLE
don't define duplicate getter for logger

### DIFF
--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -16,7 +16,8 @@ class MiqGenericMountSession < MiqFileStorage::Interface
 
   class NoSuchFileOrDirectory < RuntimeError; end
 
-  attr_accessor :settings, :mnt_point, :logger
+  attr_accessor :settings, :mnt_point
+  attr_writer :logger
 
   def initialize(log_settings)
     raise "URI missing" unless log_settings.key?(:uri)


### PR DESCRIPTION
the getter is on line 28

i don't think we should create duplicate named methods