### PR TITLE
Hide the generic run_command behind specific mount/umount API

### DIFF
--- a/lib/gems/pending/util/mount/miq_glusterfs_session.rb
+++ b/lib/gems/pending/util/mount/miq_glusterfs_session.rb
@@ -32,9 +32,9 @@ class MiqGlusterfsSession < MiqGenericMountSession
     case Sys::Platform::IMPL
     when :macosx
       mount_args[:o] = "resvport"
-      runcmd("sudo mount", :params => mount_args)
+      sudo_mount(mount_args)
     when :linux
-      runcmd("mount", :params => mount_args)
+      mount(mount_args)
     else
       raise "platform not supported"
     end

--- a/lib/gems/pending/util/mount/miq_nfs_session.rb
+++ b/lib/gems/pending/util/mount/miq_nfs_session.rb
@@ -32,9 +32,9 @@ class MiqNfsSession < MiqGenericMountSession
     case Sys::Platform::IMPL
     when :macosx
       mount_args[:o] = "resvport"
-      runcmd("sudo mount", :params => mount_args)
+      sudo_mount(mount_args)
     when :linux
-      runcmd("mount", :params => mount_args)
+      mount(mount_args)
     else
       raise "platform not supported"
     end

--- a/lib/gems/pending/util/mount/miq_smb_session.rb
+++ b/lib/gems/pending/util/mount/miq_smb_session.rb
@@ -52,7 +52,7 @@ class MiqSmbSession < MiqGenericMountSession
     logger.info("#{log_header} Connecting to host: [#{@host}], share: [#{@mount_path}], domain: [#{domain}], user: [#{user}], using mount point: [#{@mnt_point}]...")
     # mount -t cifs //192.168.252.140/temp /media/windows_share/ -o rw,username=jrafaniello,password=blah,domain=manageiq.com
 
-    runcmd("mount", :params => mount_args)
+    mount(mount_args)
     logger.info("#{log_header} Connecting to host: [#{@host}], share: [#{@mount_path}]...Complete")
   end
 end


### PR DESCRIPTION
This also fixes a subtle bug where on macOS, "sudo mount" was called
directly and if it failed it would call "sudo sudo mount".

@chessbyte Please review.