### PR TITLE
Use URI::DEFAULT_PARSER escape/unescape to avoid ruby 2.7 warnings

### DIFF
--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -78,7 +78,7 @@ class MiqGenericMountSession < MiqFileStorage::Interface
 
   def self.uri_scheme_to_class(uri)
     require 'uri'
-    scheme, userinfo, host, port, registry, share, opaque, query, fragment = URI.split(URI.encode(uri))
+    scheme, userinfo, host, port, registry, share, opaque, query, fragment = URI.split(URI::DEFAULT_PARSER.escape(uri))
     case scheme
     when 'smb'
       MiqSmbSession
@@ -327,8 +327,8 @@ class MiqGenericMountSession < MiqFileStorage::Interface
     # Only remove the log file if the current depot @settings are based on the same base URI as the log_uri to be removed
     return false if log_uri.nil? || @settings[:uri].nil?
 
-    scheme, userinfo, host, port, registry, share, opaque, query, fragment = URI.split(URI.encode(@settings[:uri]))
-    scheme_log, userinfo_log, host_log, port_log, registry_log, share_log, opaque_log, query_log, fragment_log = URI.split(URI.encode(log_uri))
+    scheme, userinfo, host, port, registry, share, opaque, query, fragment = URI.split(URI::DEFAULT_PARSER.escape(@settings[:uri]))
+    scheme_log, userinfo_log, host_log, port_log, registry_log, share_log, opaque_log, query_log, fragment_log = URI.split(URI::DEFAULT_PARSER.escape(log_uri))
 
     return false if scheme != scheme_log
     return false if host != host_log
@@ -457,7 +457,7 @@ class MiqGenericMountSession < MiqFileStorage::Interface
   def relative_to_mount(uri)
     log_header = "MIQ(#{self.class.name}-relative_to_mount)"
     logger.info("#{log_header} mount point [#{@mount_path}], uri: [#{uri}]...")
-    scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(URI.encode(uri))
+    scheme, userinfo, host, port, registry, path, opaque, query, fragment = URI.split(URI::DEFAULT_PARSER.escape(uri))
 
     # Replace any encoded spaces back into spaces since the mount commands accepts quoted spaces
     path.gsub!('%20', ' ')

--- a/lib/gems/pending/util/mount/miq_glusterfs_session.rb
+++ b/lib/gems/pending/util/mount/miq_glusterfs_session.rb
@@ -13,7 +13,7 @@ class MiqGlusterfsSession < MiqGenericMountSession
 
   def connect
     _scheme, _userinfo, @host, _port, _registry, @mount_path, _opaque, _query, _fragment =
-      URI.split(URI.encode(@settings[:uri]))
+      URI.split(URI::DEFAULT_PARSER.escape(@settings[:uri]))
     super
   end
 

--- a/lib/gems/pending/util/mount/miq_nfs_session.rb
+++ b/lib/gems/pending/util/mount/miq_nfs_session.rb
@@ -12,7 +12,7 @@ class MiqNfsSession < MiqGenericMountSession
   end
 
   def connect
-    scheme, userinfo, @host, port, registry, @mount_path, opaque, query, fragment = URI.split(URI.encode(@settings[:uri]))
+    scheme, userinfo, @host, port, registry, @mount_path, opaque, query, fragment = URI.split(URI::DEFAULT_PARSER.escape(@settings[:uri]))
     super
   end
 

--- a/lib/gems/pending/util/mount/miq_smb_session.rb
+++ b/lib/gems/pending/util/mount/miq_smb_session.rb
@@ -14,7 +14,7 @@ class MiqSmbSession < MiqGenericMountSession
   end
 
   def connect
-    scheme, userinfo, @host, port, registry, @mount_root, opaque, query, fragment = URI.split(URI.encode(@settings[:uri]))
+    scheme, userinfo, @host, port, registry, @mount_root, opaque, query, fragment = URI.split(URI::DEFAULT_PARSER.escape(@settings[:uri]))
     @mount_path = @mount_root.split("/")[0..1].join("/")
     super
   end

--- a/lib/gems/pending/util/object_storage/miq_swift_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_swift_storage.rb
@@ -16,7 +16,7 @@ class MiqSwiftStorage < MiqObjectStorage
     @bucket_name = URI(@settings[:uri]).host
 
     raise "username and password are required values!" if @settings[:username].nil? || @settings[:password].nil?
-    _scheme, _userinfo, @host, @port, _registry, path, _opaque, query, _fragment = URI.split(URI.encode(@settings[:uri]))
+    _scheme, _userinfo, @host, @port, _registry, path, _opaque, query, _fragment = URI.split(URI::DEFAULT_PARSER.escape(@settings[:uri]))
     query_params(query) if query
     @swift          = nil
     @username       = @settings[:username]
@@ -30,7 +30,7 @@ class MiqSwiftStorage < MiqObjectStorage
   def uri_to_object_path(remote_file)
     # Strip off the leading "swift://" and the container name from the URI"
     # Also remove the leading delimiter.
-    object_file_with_bucket = URI.split(URI.encode(remote_file))[5]
+    object_file_with_bucket = URI.split(URI::DEFAULT_PARSER.escape(remote_file))[5]
     object_file_with_bucket.split(File::Separator)[2..-1].join(File::Separator)
   end
 


### PR DESCRIPTION
Fixes various warnings of this variety:
app/models/file_depot_ftp.rb:128: warning: URI.escape is obsolete
app/models/mixins/file_depot_mixin.rb:42: warning: URI.escape is obsolete

From: https://github.com/ManageIQ/manageiq/pull/21036

Related: https://github.com/ManageIQ/manageiq/issues/19678