### PR TITLE
[LASKER] Lockdown tests to use ruby 2.6.6 per ManageIQ/manageiq#19678

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@
 cache: bundler
 language: ruby
 rvm:
-- 2.5.8
 - 2.6.6
 addons:
   postgresql: '10'


### PR DESCRIPTION
Lockdown tests to use ruby 2.6.6 per ManageIQ/manageiq#19678