### PR TITLE
Truncate log lines to 8Kb

### DIFF
--- a/lib/gems/pending/util/vmdb-logger.rb
+++ b/lib/gems/pending/util/vmdb-logger.rb
@@ -5,7 +5,7 @@ require 'active_support/core_ext/string'
 require 'English'
 
 class VMDBLogger < Logger
-  MAX_LOG_LINE_LENGTH = 1.megabyte
+  MAX_LOG_LINE_LENGTH = 8.kilobytes
 
   def initialize(*args)
     super

--- a/spec/util/vmdb-logger_spec.rb
+++ b/spec/util/vmdb-logger_spec.rb
@@ -96,9 +96,9 @@ b:
 
   context "long messages" do
     it "truncates long messages when max_message_size is set" do
-      msg = "a" * 1_572_864 # 1.5 mb in bytes
+      msg = "a" * 10.kilobytes
       _, message = VMDBLogger::Formatter.new.call(:error, Time.now.utc, "", msg).split("-- : ")
-      expect(message.strip.size).to eq(1.megabyte)
+      expect(message.strip.size).to eq(8.kilobytes)
     end
   end
 


### PR DESCRIPTION
A recent issue had log lines that were 30K, and even that was proving to
be too long and relatively useless. journald limits log line length to
about 8kb, so this feels like a reasonable value.

@agrare Please review.