### PR TITLE
[MiqGenericMountSession] Fix umount method scoping

### DIFF
--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -16,6 +16,12 @@ class MiqGenericMountSession < MiqFileStorage::Interface
 
   class NoSuchFileOrDirectory < RuntimeError; end
 
+  class << self
+    def run_command(command, args)
+      AwesomeSpawn.run!(command, :params => args, :combined_output => true).output
+    end
+  end
+
   attr_accessor :settings, :mnt_point
   attr_writer :logger
 
@@ -30,7 +36,7 @@ class MiqGenericMountSession < MiqFileStorage::Interface
   end
 
   def mount(args)
-    run_command("mount", args)
+    self.class.run_command("mount", args)
   rescue AwesomeSpawn::CommandResultError => err
     raise if err.result.exit_status != 1
 
@@ -38,10 +44,10 @@ class MiqGenericMountSession < MiqFileStorage::Interface
   end
 
   def sudo_mount(args)
-    run_command("sudo mount", args)
+    self.class.run_command("sudo mount", args)
   end
 
-  def umount(mount_point)
+  def self.umount(mount_point)
     run_command("umount", [mount_point])
   rescue AwesomeSpawn::CommandResultError => err
     raise if err.result.exit_status != 1
@@ -49,12 +55,8 @@ class MiqGenericMountSession < MiqFileStorage::Interface
     sudo_umount(mount_point)
   end
 
-  def sudo_umount(mount_point)
+  def self.sudo_umount(mount_point)
     run_command("sudo umount", [mount_point])
-  end
-
-  private def run_command(command, args)
-    AwesomeSpawn.run!(command, :params => args, :combined_output => true).output
   end
 
   def self.in_depot_session(opts, &_block)

--- a/spec/util/mount/miq_generic_mount_session_spec.rb
+++ b/spec/util/mount/miq_generic_mount_session_spec.rb
@@ -66,21 +66,21 @@ describe MiqGenericMountSession do
     it "works on success" do
       stub_good_run!("umount", :params => [mount_point], :combined_output => true)
 
-      described_class.new(:uri => nil).umount(mount_point)
+      described_class.umount(mount_point)
     end
 
     it "will retry with sudo on failure" do
       stub_bad_run!("umount",       :params => [mount_point], :combined_output => true)
       stub_good_run!("sudo umount", :params => [mount_point], :combined_output => true)
 
-      described_class.new(:uri => nil).umount(mount_point)
+      described_class.umount(mount_point)
     end
 
     it "raises on failure and sudo failure" do
       stub_bad_run!("umount",      :params => [mount_point], :combined_output => true)
       stub_bad_run!("sudo umount", :params => [mount_point], :combined_output => true)
 
-      expect { described_class.new(:uri => nil).umount(mount_point) }.to raise_error(AwesomeSpawn::CommandResultError)
+      expect { described_class.umount(mount_point) }.to raise_error(AwesomeSpawn::CommandResultError)
     end
   end
 
@@ -90,13 +90,13 @@ describe MiqGenericMountSession do
     it "works on success" do
       stub_good_run!("sudo umount", :params => [mount_point], :combined_output => true)
 
-      described_class.new(:uri => nil).sudo_umount(mount_point)
+      described_class.sudo_umount(mount_point)
     end
 
     it "raises on failure" do
       stub_bad_run!("sudo umount", :params => [mount_point], :combined_output => true)
 
-      expect { described_class.new(:uri => nil).sudo_umount(mount_point) }.to raise_error(AwesomeSpawn::CommandResultError)
+      expect { described_class.sudo_umount(mount_point) }.to raise_error(AwesomeSpawn::CommandResultError)
     end
   end
 end


### PR DESCRIPTION
When the mounting code changed in the following commit: d6898989dbd32d145710924adebcc2e2f2e681b2

The scope of the methods that needed to be called in raw_disconnect was class methods, and not instances methods.  Unfortunately, they were created as class methods, so this fixes that.

Links
-----

* https://github.com/ManageIQ/manageiq-gems-pending/pull/511