### PR TITLE
Require minimum nokogiri 1.11.4 and allow minor version updates

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "net-scp",                 "~> 1.2.1"
   s.add_runtime_dependency "net-sftp",                "~> 2.1.2"
   s.add_runtime_dependency "net-ssh",                 "~> 4.2.0"
-  s.add_runtime_dependency "nokogiri",                "~> 1.10.8"
+  s.add_runtime_dependency "nokogiri",                "~> 1.11", ">= 1.11.4"
   s.add_runtime_dependency "rake",                    ">= 12.3.3"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"


### PR DESCRIPTION

https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-7rrm-v45f-jp64

CVE-2020-26247
https://github.com/sparklemotion/nokogiri/security/advisories/GHSA-vr8q-g5c7-m54m

We're loosening the dependency here because patch level updates for nokogiri is
overly restrictive.  It's a stable library and if we have a breakage, we want to
know about it as soon as possible.