### PR TITLE
[VMDBLogger] Fix kwargs warnings

### DIFF
--- a/lib/gems/pending/util/vmdb-logger.rb
+++ b/lib/gems/pending/util/vmdb-logger.rb
@@ -7,7 +7,7 @@ require 'English'
 class VMDBLogger < Logger
   MAX_LOG_LINE_LENGTH = 8.kilobytes
 
-  def initialize(*args)
+  def initialize(*args, **kwargs)
     super
     self.level = INFO
 


### PR DESCRIPTION
### Example

```console
$ bin/rails c
~/.gem/ruby/2.7.1/bundler/gems/manageiq-gems-pending-7969c8312a48/lib/gems/pending/util/vmdb-logger.rb:11: warning: Using the last argument as keyword parameters is deprecated; maybe ** should be added to the call
~/.rubies/ruby-2.7.1/lib/ruby/2.7.0/logger.rb:379: warning: The called method `initialize' is defined here
** ManageIQ master, codename: Najdorf
Loading development environment (Rails 6.0.4.1)
irb(main):001:0>
```