### PR TITLE
Fix simplecov handling for codeclimate via GitHub Actions

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -19,6 +19,8 @@ jobs:
         bundler-cache: true
     - name: Run tests
       run: bundle exec rake
+      env:
+        CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
     - if: ${{ github.ref == 'refs/heads/master' && matrix.ruby-version == '2.7' }}
       name: Report code coverage
       continue-on-error: true

--- a/Rakefile
+++ b/Rakefile
@@ -4,5 +4,8 @@ require 'rake'
 require 'rake/testtask'
 
 RSpec::Core::RakeTask.new(:spec)
+Rake::TestTask.new do |t|
+  t.test_files = FileList['test/**/ts_*.rb']
+end
 
 task :default => [:spec, :test]

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -46,7 +46,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "manageiq-style"
   s.add_development_dependency "pg"
   s.add_development_dependency "rspec",                     "~> 3.5.0"
-  s.add_development_dependency "simplecov"
+  s.add_development_dependency "simplecov",                 ">= 0.21.2"
   s.add_development_dependency "test-unit"
   s.add_development_dependency "timecop",                   "~> 0.9.1"
   s.add_development_dependency "xml-simple",                "~> 1.1.0"

--- a/spec/coverage_helper.rb
+++ b/spec/coverage_helper.rb
@@ -1,6 +1,6 @@
 require 'active_support/core_ext/kernel/reporting'
 
-# Require all ruby files for accuracte test coverage reports
+# Require all ruby files for accurate test coverage reports
 EXCLUSIONS_LIST = %w(/bin/ /ext/ /spec/ /test/ /vendor/ appliance_console.rb test.rb require_with_logging.rb).freeze
 Dir.glob(ManageIQ::Gems::Pending.root.join("**", "*.rb")).each do |file|
   next if EXCLUSIONS_LIST.any? { |exclusion| file.include?(exclusion) }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,5 @@
 require "simplecov"
-SimpleCov.start { command_name "spec" }
+SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'manageiq-gems-pending'

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,5 +1,5 @@
 require 'simplecov'
-SimpleCov.start { command_name "test" }
+SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'manageiq/gems/pending'


### PR DESCRIPTION
When running the tests, we need to make sure the CC_TEST_REPORTER_ID
value is present. This allows SimpleCov to generate the JSON payload
that is needed for Code Climate, as SimpleCov has special handling when
that env var is present.

Also fix calling of minitest based tests