### PR TITLE
Remove handsoap

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,5 +5,3 @@ gemspec
 
 plugin "bundler-inject", "~> 1.1"
 require File.join(Bundler::Plugin.index.load_paths("bundler-inject")[0], "bundler-inject") rescue nil
-
-gem "handsoap", "=0.2.5.5", :require => false, :source => "http://rubygems.manageiq.org"


### PR DESCRIPTION
handsoap was removed from the gemspec, but accidentally left in the
Gemfile.  This removes it completely.

@agrare Please review.