### PR TITLE
Bump more_core_extensions for v4.4.0

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -26,7 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "bundler",                 "~> 2.1", ">= 2.1.4", "!= 2.2.10"
   s.add_runtime_dependency "erubis",                  "= 2.7.0" # For winrm-elevated; can be removed when we upgrade to winrm-elevated >= 1.1.2
   s.add_runtime_dependency "fog-openstack",           "~> 0.3"
-  s.add_runtime_dependency "more_core_extensions",    "~> 4.3"
+  s.add_runtime_dependency "more_core_extensions",    "~> 4.4"
   s.add_runtime_dependency "nokogiri",                "~> 1.11", ">= 1.11.4"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"


### PR DESCRIPTION
Pull in fix for https://github.com/ManageIQ/more_core_extensions/pull/106
Used by https://github.com/ManageIQ/manageiq-providers-kubevirt/pull/203