### PR TITLE
Bump nokogiri to >= 1.13.6

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "erubis",                  "= 2.7.0" # For winrm-elevated; can be removed when we upgrade to winrm-elevated >= 1.1.2
   s.add_runtime_dependency "fog-openstack",           "~> 0.3"
   s.add_runtime_dependency "more_core_extensions",    "~> 4.4"
-  s.add_runtime_dependency "nokogiri",                "~> 1.11", ">= 1.11.4"
+  s.add_runtime_dependency "nokogiri",                "~> 1.13", ">= 1.13.6"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"
   s.add_runtime_dependency "winrm",                   "~> 2.1"


### PR DESCRIPTION
https://github.com/ManageIQ/amazon_ssa_support/issues/77

Don't want to say this will resolve that yet, since amazon_ssa_support pulls in 1.13.6 already so whitesource seems out of date