### PR TITLE
 Add zeitwerk loader and teach it about this gem

### DIFF
--- a/lib/gems/pending/util/duplicate_blocker.rb
+++ b/lib/gems/pending/util/duplicate_blocker.rb
@@ -125,6 +125,3 @@ module DuplicateBlocker
     end
   end
 end
-
-require 'util/duplicate_blocker/dedup_handler'
-require 'util/duplicate_blocker/duplicate_found_exception'

--- a/lib/gems/pending/util/miq-extensions.rb
+++ b/lib/gems/pending/util/miq-extensions.rb
@@ -1,3 +1,2 @@
 require 'active_support/inflector'
-require 'manageiq-gems-pending'
 require 'more_core_extensions/all'

--- a/lib/gems/pending/util/miq-ipmi.rb
+++ b/lib/gems/pending/util/miq-ipmi.rb
@@ -7,7 +7,7 @@
 #   freeipmi.x86_64
 
 require 'awesome_spawn'
-require 'util/miq-extensions'
+require_relative 'miq-extensions'
 
 class MiqIPMI
   def initialize(server = nil, username = nil, password = nil)

--- a/lib/gems/pending/util/miq-process.rb
+++ b/lib/gems/pending/util/miq-process.rb
@@ -3,7 +3,6 @@
 require 'awesome_spawn'
 require 'sys-uname'
 require 'sys/proctable'
-require 'util/miq-system'
 
 class MiqProcess
   # Collect and return a list of PID's for all processes that match
@@ -81,7 +80,6 @@ class MiqProcess
 
     case Sys::Platform::IMPL
     when :mswin, :mingw
-      require 'util/win32/miq-wmi'
       # WorkingSetSize: The amount of memory in bytes that a process needs to execute efficiently, for an operating system that uses
       #                 page-based memory management. If an insufficient amount of memory is available (< working set size), thrashing will occur.
       # KernelModeTime: Time in kernel mode, in 100 nanoseconds
@@ -151,7 +149,6 @@ class MiqProcess
   end
 
   def self.process_list_wmi(wmi = nil, pid = nil)
-    require 'util/win32/miq-wmi'
     pl = {}
     wmi = WMIHelper.connectServer if wmi.nil?
     os_data = wmi.get_instance('select TotalVisibleMemorySize from Win32_OperatingSystem')

--- a/lib/gems/pending/util/miq-system.rb
+++ b/lib/gems/pending/util/miq-system.rb
@@ -1,9 +1,6 @@
 require 'active_support/core_ext/object/blank'
 require 'awesome_spawn'
 require 'sys-uname'
-if Sys::Platform::OS == :windows
-  require 'util/win32/miq-wmi'
-end
 
 class MiqSystem
   @@cpu_usage_vmstat_output_mtime = nil

--- a/lib/gems/pending/util/miq-xml.rb
+++ b/lib/gems/pending/util/miq-xml.rb
@@ -1,9 +1,5 @@
 require 'time'
-require 'util/xml/miq_rexml'
-require 'util/xml/xml_hash'
-require 'util/miq-encode'
-require 'util/xml/xml_diff'
-require 'util/xml/xml_patch'
+require 'util/xml/miq_rexml' # we must monkey patch rexml early
 
 class MiqXml
   MIQ_XML_VERSION = 2.1 # Refactor Nokogiri handling

--- a/lib/gems/pending/util/miq-xml.rb
+++ b/lib/gems/pending/util/miq-xml.rb
@@ -42,7 +42,7 @@ class MiqXml
       when :xmlhash
         XmlHash::Document
       when :nokogiri
-        require 'util/xml/miq_nokogiri'
+        require_relative 'xml/miq_nokogiri'
         @nokogiri = true
         Nokogiri::XML::Document
       else

--- a/lib/gems/pending/util/miq_file_storage.rb
+++ b/lib/gems/pending/util/miq_file_storage.rb
@@ -46,6 +46,13 @@ class MiqFileStorage
   private_class_method :fetch_interface_class
 
   def self.storage_interface_classes
+    # TODO: this method expects these classes to be eager loaded.
+    # Once we eager load, we can remove these.
+    ::MiqGlusterfsSession
+    ::MiqLocalMountSession
+    ::MiqNfsSession
+    ::MiqSmbSession
+
     @storage_interface_classes ||= Interface.descendants.each_with_object({}) do |klass, memo|
       memo[klass.uri_scheme] = klass if klass.uri_scheme
     end

--- a/lib/gems/pending/util/miq_object_storage.rb
+++ b/lib/gems/pending/util/miq_object_storage.rb
@@ -1,11 +1,6 @@
 require 'net/protocol'
-require 'util/miq_file_storage'
 
 class MiqObjectStorage < MiqFileStorage::Interface
-  require 'util/object_storage/miq_s3_storage'
-  require 'util/object_storage/miq_ftp_storage'
-  require 'util/object_storage/miq_swift_storage'
-
   attr_accessor :settings
   attr_writer   :logger
 

--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -5,15 +5,7 @@ require 'sys-uname'
 require 'uri'
 require 'awesome_spawn'
 
-require 'util/miq-exception'
-require 'util/miq_file_storage'
-
 class MiqGenericMountSession < MiqFileStorage::Interface
-  require 'util/mount/miq_local_mount_session'
-  require 'util/mount/miq_nfs_session'
-  require 'util/mount/miq_smb_session'
-  require 'util/mount/miq_glusterfs_session'
-
   class NoSuchFileOrDirectory < RuntimeError; end
 
   class << self

--- a/lib/gems/pending/util/mount/miq_glusterfs_session.rb
+++ b/lib/gems/pending/util/mount/miq_glusterfs_session.rb
@@ -1,5 +1,3 @@
-require 'util/mount/miq_generic_mount_session'
-
 class MiqGlusterfsSession < MiqGenericMountSession
   PORTS = [2049, 111].freeze
 

--- a/lib/gems/pending/util/mount/miq_local_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_local_mount_session.rb
@@ -1,5 +1,3 @@
-require 'util/mount/miq_generic_mount_session'
-
 # MiqLocalMountSession is meant to be a representation of the local file system
 # that conforms to the same interface as MiqLocalMountSession (and by proxy,
 # MiqFileSystem::Interface).

--- a/lib/gems/pending/util/mount/miq_nfs_session.rb
+++ b/lib/gems/pending/util/mount/miq_nfs_session.rb
@@ -1,5 +1,3 @@
-require 'util/mount/miq_generic_mount_session'
-
 class MiqNfsSession < MiqGenericMountSession
   PORTS = [2049, 111]
 

--- a/lib/gems/pending/util/mount/miq_smb_session.rb
+++ b/lib/gems/pending/util/mount/miq_smb_session.rb
@@ -1,5 +1,3 @@
-require 'util/mount/miq_generic_mount_session'
-
 class MiqSmbSession < MiqGenericMountSession
   PORTS = [445, 139]
 

--- a/lib/gems/pending/util/object_storage/miq_ftp_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_ftp_storage.rb
@@ -1,5 +1,3 @@
-require 'util/miq_ftp_lib'
-require 'util/miq_object_storage'
 require 'logger'
 
 class MiqFtpStorage < MiqObjectStorage

--- a/lib/gems/pending/util/object_storage/miq_s3_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_s3_storage.rb
@@ -1,5 +1,3 @@
-require 'util/miq_object_storage'
-
 class MiqS3Storage < MiqObjectStorage
   attr_reader :bucket_name
 

--- a/lib/gems/pending/util/object_storage/miq_swift_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_swift_storage.rb
@@ -1,5 +1,3 @@
-require 'util/miq_object_storage'
-
 class MiqSwiftStorage < MiqObjectStorage
   attr_reader :container_name
 

--- a/lib/gems/pending/util/win32/miq-powershell.rb
+++ b/lib/gems/pending/util/win32/miq-powershell.rb
@@ -1,8 +1,8 @@
 require 'awesome_spawn'
-require 'util/miq-xml'
 require 'io/wait'
 require 'open-uri'
-require 'util/miq-encode'
+
+# Not to be confused with our own win32 directory, this is in stdlib on windows
 require 'win32/registry' if Sys::Platform::OS == :windows
 
 module MiqPowerShell

--- a/lib/gems/pending/util/win32/miq-wmi-linux.rb
+++ b/lib/gems/pending/util/win32/miq-wmi-linux.rb
@@ -1,4 +1,3 @@
-require 'util/miq-hash_struct'
 require 'open3'
 require 'awesome_spawn'
 

--- a/lib/gems/pending/util/win32/miq-wmi.rb
+++ b/lib/gems/pending/util/win32/miq-wmi.rb
@@ -4,10 +4,11 @@ class WMIHelper
   WMI_ROOT_NAMESPACE = "root\\cimv2" unless defined?(WMI_ROOT_NAMESPACE)
 
   platform = Sys::Platform::IMPL
-  unless platform == :macosx
-    platform = :mswin if platform == :mingw
-    require "util/win32/miq-wmi-#{platform}"
-    include Kernel.const_get("Wmi#{platform.to_s.capitalize}")
+  case platform
+  when :linux
+    include WmiLinux
+  when :mswin
+    include WmiMswin
   end
 
   def initialize(server = nil, username = nil, password = nil, namespace = WMI_ROOT_NAMESPACE)

--- a/lib/gems/pending/util/xml/miq_nokogiri.rb
+++ b/lib/gems/pending/util/xml/miq_nokogiri.rb
@@ -1,8 +1,6 @@
 begin
   # Try to load the nokogiri library bindings.  If it fails then we skip defining the methods below.
   require 'nokogiri'
-  require 'util/xml/xml_diff'
-  require 'util/xml/xml_patch'
 
   # Add class methods to nokogiri to have it behave more like REXML for easy replacement
   module Nokogiri

--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -1,10 +1,6 @@
 require 'time'
 require 'rexml/document'
-require 'util/miq-encode'
-require 'util/xml/xml_hash'
-require 'util/xml/xml_utils'
-require 'util/xml/xml_diff'
-require 'util/xml/xml_patch'
+require_relative 'xml_utils'
 
 class MIQRexml
   # MIQ_XML_VERSION = 1.0

--- a/lib/gems/pending/util/xml/xml_hash.rb
+++ b/lib/gems/pending/util/xml/xml_hash.rb
@@ -303,9 +303,6 @@ module XmlHash
 
   # There is no difference between a document and an element here
   class Document < Hash
-    require 'util/xml/xml_diff'
-    require 'util/xml/xml_patch'
-
     include MiqXmlDiff
     include MiqXmlPatch
 

--- a/lib/gems/pending/util/xml/xml_utils.rb
+++ b/lib/gems/pending/util/xml/xml_utils.rb
@@ -1,6 +1,3 @@
-require 'util/miq-xml'
-require 'util/xml/xml_hash'
-
 class XmlFind
   def self.decode(data, format)
     method = data.kind_of?(Hash) ? :findNamedElement_hash : :findNamedElement

--- a/lib/manageiq-gems-pending.rb
+++ b/lib/manageiq-gems-pending.rb
@@ -1,1 +1,52 @@
 require 'manageiq/gems/pending'
+
+require "zeitwerk"
+loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
+loader.ignore(__FILE__)
+
+# For straight requires from here
+loader.push_dir("#{__dir__}/gems/pending/util")
+
+# This tells the loader to not expect Mount or ObjectStorage namspaces...
+loader.collapse("#{__dir__}/gems/pending/util/mount")
+loader.collapse("#{__dir__}/gems/pending/util/object_storage")
+loader.collapse("#{__dir__}/gems/pending/util/win32")
+loader.collapse("#{__dir__}/gems/pending/util/xml")
+
+# These files skip zeitwerk and must be required manually
+##### TODO: check for requires outside of this gem to these files and util/ in requires
+loader.ignore("#{__dir__}/gems/pending/util/miq-extensions.rb")       # loader file, no class
+loader.ignore("#{__dir__}/gems/pending/util/require_with_logging.rb") # file has no class ;-)
+loader.ignore("#{__dir__}/gems/pending/util/xml/miq_nokogiri.rb")     # monkey patch, so no class
+loader.ignore("#{__dir__}/gems/pending/util/xml/xml_utils.rb")        # multiple classes in one file
+
+# These inflectors teach zeitwerk our naming convention here
+loader.inflector.inflect(
+  "manageiq"  => "ManageIQ",
+  "version"   => "VERSION",  # TODO: why is this needed, for_gem is supposed to do this
+)
+
+# These inflectors are teaching zeitwerk when we fail at conventions.
+# It expects downcased and underscored file names (not hyphens).
+# TODO: These could be fixed but require changing client code to use the new constant.
+loader.inflector.inflect(
+  "miq-encode"      => "MIQEncode",
+  "miq-exception"   => "MiqException",
+  "miq-hash_struct" => "MiqHashStruct",
+  "miq-ipmi"        => "MiqIPMI",
+  "miq-powershell"  => "MiqPowerShell",
+  "miq-process"     => "MiqProcess",
+  "miq-system"      => "MiqSystem",
+  "miq-wmi"         => "WMIHelper",     # WAT
+  "miq-wmi-linux"   => "WmiLinux",
+  "miq-wmi-mswin"   => "WmiMswin",
+  "miq-xml"         => "MiqXml",
+  "miq_rexml"       => "MIQRexml",
+  "xml_diff"        => "MiqXmlDiff",
+  "xml_patch"       => "MiqXmlPatch",
+)
+
+loader.setup
+
+# TODO: consider turning on eager_load and only disable really slow/fat requires
+# loader.eager_load

--- a/lib/manageiq/gems/pending.rb
+++ b/lib/manageiq/gems/pending.rb
@@ -1,7 +1,5 @@
-# In case this is required directly
-require 'manageiq-gems-pending'
-
 require "manageiq/gems/pending/version"
+require 'manageiq/gems/pending/zeitwerk'
 
 module ManageIQ
   module Gems

--- a/lib/manageiq/gems/pending.rb
+++ b/lib/manageiq/gems/pending.rb
@@ -1,3 +1,6 @@
+# In case this is required directly
+require 'manageiq-gems-pending'
+
 require "manageiq/gems/pending/version"
 
 module ManageIQ

--- a/lib/manageiq/gems/pending/zeitwerk.rb
+++ b/lib/manageiq/gems/pending/zeitwerk.rb
@@ -1,29 +1,27 @@
-require 'manageiq/gems/pending'
-
 require "zeitwerk"
-loader = Zeitwerk::Loader.for_gem(warn_on_extra_files: false)
+loader = Zeitwerk::Loader.for_gem_extension(ManageIQ::Gems::Pending)
 loader.ignore(__FILE__)
 
 # For straight requires from here
-loader.push_dir("#{__dir__}/gems/pending/util")
+lib = File.expand_path("#{__dir__}../../../../")
+loader.push_dir("#{lib}/gems/pending/util")
 
-# This tells the loader to not expect Mount or ObjectStorage namspaces...
-loader.collapse("#{__dir__}/gems/pending/util/mount")
-loader.collapse("#{__dir__}/gems/pending/util/object_storage")
-loader.collapse("#{__dir__}/gems/pending/util/win32")
-loader.collapse("#{__dir__}/gems/pending/util/xml")
+# This tells the loader to not expect Mount or ObjectStorage namespaces...
+loader.collapse("#{lib}/gems/pending/util/mount")
+loader.collapse("#{lib}/gems/pending/util/object_storage")
+loader.collapse("#{lib}/gems/pending/util/win32")
+loader.collapse("#{lib}/gems/pending/util/xml")
 
 # These files skip zeitwerk and must be required manually
 ##### TODO: check for requires outside of this gem to these files and util/ in requires
-loader.ignore("#{__dir__}/gems/pending/util/miq-extensions.rb")       # loader file, no class
-loader.ignore("#{__dir__}/gems/pending/util/require_with_logging.rb") # file has no class ;-)
-loader.ignore("#{__dir__}/gems/pending/util/xml/miq_nokogiri.rb")     # monkey patch, so no class
-loader.ignore("#{__dir__}/gems/pending/util/xml/xml_utils.rb")        # multiple classes in one file
+loader.ignore("#{lib}/gems/pending/util/miq-extensions.rb")       # loader file, no class
+loader.ignore("#{lib}/gems/pending/util/require_with_logging.rb") # file has no class ;-)
+loader.ignore("#{lib}/gems/pending/util/xml/miq_nokogiri.rb")     # monkey patch, so no class
+loader.ignore("#{lib}/gems/pending/util/xml/xml_utils.rb")        # multiple classes in one file
 
 # These inflectors teach zeitwerk our naming convention here
 loader.inflector.inflect(
-  "manageiq"  => "ManageIQ",
-  "version"   => "VERSION",  # TODO: why is this needed, for_gem is supposed to do this
+  "version" => "VERSION" # TODO: why is this needed, for_gem_extension is supposed to do this
 )
 
 # These inflectors are teaching zeitwerk when we fail at conventions.
@@ -37,13 +35,13 @@ loader.inflector.inflect(
   "miq-powershell"  => "MiqPowerShell",
   "miq-process"     => "MiqProcess",
   "miq-system"      => "MiqSystem",
-  "miq-wmi"         => "WMIHelper",     # WAT
+  "miq-wmi"         => "WMIHelper", # WAT
   "miq-wmi-linux"   => "WmiLinux",
   "miq-wmi-mswin"   => "WmiMswin",
   "miq-xml"         => "MiqXml",
   "miq_rexml"       => "MIQRexml",
   "xml_diff"        => "MiqXmlDiff",
-  "xml_patch"       => "MiqXmlPatch",
+  "xml_patch"       => "MiqXmlPatch"
 )
 
 loader.setup

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -30,7 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"
   s.add_runtime_dependency "win32ole",                "~> 1.8.8" # this gem was extracted in ruby 3 - required if we use wmi on windows
-  s.add_runtime_dependency "zeitwerk",                "~> 2.6"
+  s.add_runtime_dependency "zeitwerk",                "~> 2.6", ">= 2.6.8"
 
   s.add_development_dependency "ftpd",                      "~> 2.1.0"
   s.add_development_dependency "manageiq-style"

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -30,6 +30,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"
   s.add_runtime_dependency "win32ole",                "~> 1.8.8" # this gem was extracted in ruby 3 - required if we use wmi on windows
+  s.add_runtime_dependency "zeitwerk",                "~> 2.6"
 
   s.add_development_dependency "ftpd",                      "~> 2.1.0"
   s.add_development_dependency "manageiq-style"

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require "simplecov"
 SimpleCov.start
 
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
-require 'manageiq-gems-pending'
+require 'manageiq/gems/pending'
 
 # Initialize the global logger that might be expected
 require 'logger'

--- a/spec/util/duplicate_blocker_spec.rb
+++ b/spec/util/duplicate_blocker_spec.rb
@@ -1,5 +1,4 @@
 require "logger"
-require "util/duplicate_blocker"
 require "timecop"
 
 describe DuplicateBlocker do

--- a/spec/util/miq-hash_struct_spec.rb
+++ b/spec/util/miq-hash_struct_spec.rb
@@ -1,4 +1,3 @@
-require 'util/miq-hash_struct'
 require 'yaml'
 
 describe MiqHashStruct do

--- a/spec/util/miq-ipmi_spec.rb
+++ b/spec/util/miq-ipmi_spec.rb
@@ -1,5 +1,3 @@
-require "util/miq-ipmi"
-
 describe MiqIPMI do
   subject { described_class.new }
 

--- a/spec/util/miq-process_spec.rb
+++ b/spec/util/miq-process_spec.rb
@@ -1,5 +1,3 @@
-require 'util/miq-process'
-
 describe MiqProcess do
   context ".command_line" do
     it "exited process" do

--- a/spec/util/miq-system_spec.rb
+++ b/spec/util/miq-system_spec.rb
@@ -1,5 +1,3 @@
-require 'util/miq-system'
-
 describe MiqSystem do
   context ".normalize_df_file_argument" do
     it "nil" do

--- a/spec/util/miq-xml_spec.rb
+++ b/spec/util/miq-xml_spec.rb
@@ -1,5 +1,3 @@
-require 'util/miq-xml'
-
 describe MiqXml do
   it "handles loaded document encoding" do
     attr_string = "string \xC2\xAE"

--- a/spec/util/miq_file_storage_spec.rb
+++ b/spec/util/miq_file_storage_spec.rb
@@ -1,6 +1,3 @@
-require "util/mount/miq_generic_mount_session"
-require "util/miq_object_storage"
-
 describe MiqFileStorage do
   def opts_for_nfs
     opts[:uri] = "nfs://example.com/share/path/to/file.txt"

--- a/spec/util/miq_ftp_lib_spec.rb
+++ b/spec/util/miq_ftp_lib_spec.rb
@@ -1,4 +1,3 @@
-require 'util/miq_ftp_lib'
 require 'logger' # probably loaded elsewhere, but for the below classes
 
 class FTPKlass

--- a/spec/util/miq_logger_processor_spec.rb
+++ b/spec/util/miq_logger_processor_spec.rb
@@ -1,5 +1,3 @@
-require 'util/miq_logger_processor'
-
 describe MiqLoggerProcessor do
   MLP_DATA_DIR = File.expand_path(File.join(File.dirname(__FILE__), 'data'))
 

--- a/spec/util/miq_object_storage_spec.rb
+++ b/spec/util/miq_object_storage_spec.rb
@@ -1,6 +1,4 @@
 require "fileutils"
-require "util/mount/miq_generic_mount_session"
-require "util/miq_object_storage"
 
 class MockLocalFileStorage < MiqObjectStorage
   def initialize(source_path = nil, byte_count = 2.megabytes)

--- a/spec/util/mount/miq_generic_mount_session_spec.rb
+++ b/spec/util/mount/miq_generic_mount_session_spec.rb
@@ -1,4 +1,3 @@
-require "util/mount/miq_generic_mount_session"
 require "awesome_spawn/spec_helper"
 
 describe MiqGenericMountSession do

--- a/spec/util/mount/miq_local_mount_session_spec.rb
+++ b/spec/util/mount/miq_local_mount_session_spec.rb
@@ -1,4 +1,3 @@
-require 'util/mount/miq_local_mount_session'
 require 'tempfile'
 
 describe MiqLocalMountSession do

--- a/spec/util/object_storage/miq_ftp_storage_spec.rb
+++ b/spec/util/object_storage/miq_ftp_storage_spec.rb
@@ -1,5 +1,3 @@
-require 'util/object_storage/miq_ftp_storage.rb'
-
 describe MiqFtpStorage, :with_ftp_server do
   subject         { described_class.new(ftp_creds.merge(:uri => "ftp://localhost")) }
   let(:ftp_creds) { { :username => "ftpuser", :password => "ftppass" } }

--- a/spec/util/object_storage/miq_s3_storage_spec.rb
+++ b/spec/util/object_storage/miq_s3_storage_spec.rb
@@ -1,5 +1,3 @@
-require "util/object_storage/miq_s3_storage"
-
 describe MiqS3Storage do
   before(:each) do
     @uri = "s3://tmp/abc/def"

--- a/spec/util/object_storage/miq_swift_storage_spec.rb
+++ b/spec/util/object_storage/miq_swift_storage_spec.rb
@@ -1,5 +1,3 @@
-require "util/object_storage/miq_swift_storage"
-
 describe MiqSwiftStorage do
   let(:object_storage) { described_class.new(:uri => uri, :username => 'user', :password => 'pass') }
 

--- a/spec/util/win32/miq-powershell_spec.rb
+++ b/spec/util/win32/miq-powershell_spec.rb
@@ -1,4 +1,3 @@
-require 'util/win32/miq-powershell'
 require 'time'
 
 describe MiqPowerShell do

--- a/spec/util/xml/miq_nokogiri_spec.rb
+++ b/spec/util/xml/miq_nokogiri_spec.rb
@@ -1,4 +1,3 @@
-require 'util/miq-xml'
 require 'nokogiri'
 
 describe "miq_nokogiri" do

--- a/spec/util/xml/miq_rexml_spec.rb
+++ b/spec/util/xml/miq_rexml_spec.rb
@@ -1,4 +1,3 @@
-require 'util/miq-xml'
 require_relative "./shared_examples_for_xml_base_parser"
 
 describe MIQRexml do

--- a/spec/util/xml/miq_xmlhash_spec.rb
+++ b/spec/util/xml/miq_xmlhash_spec.rb
@@ -1,4 +1,3 @@
-require 'util/miq-xml'
 require 'xmlsimple'
 require_relative "./shared_examples_for_xml_base_parser"
 


### PR DESCRIPTION
Depends on:
- [x] Core using classic loader (just this PR) - green cross repo: https://github.com/ManageIQ/manageiq-cross_repo-tests/pull/800 

* specify load path directories
* inform of organizational directories that aren't namespaces
* specific files that must be required and not autoloaded
* custom inflectors where we deviate from convention
* remove requires for autoload-able files (caution must be taken when we need to monkey patch as we need to require or we may never get our monkey patch loaded)
* use require_relative for ones that must be manually required

TODO:

- [x] Extract commits that are completely backward compatible https://github.com/ManageIQ/manageiq-gems-pending/pull/559
- [x] Keep WIP the remaining parts that depend on having zeitwerk
- [x] Merge PRs removing dependency on lib/manageiq-gems-pending.rb file
  - [x] https://github.com/ManageIQ/manageiq/pull/22548
  - [x] https://github.com/ManageIQ/amazon_ssa_support/pull/96 