### PR TITLE
Bump nokogiri minimum for recent CVEs

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -27,7 +27,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "erubis",                  "= 2.7.0" # For winrm-elevated; can be removed when we upgrade to winrm-elevated >= 1.1.2
   s.add_runtime_dependency "fog-openstack",           "~> 0.3"
   s.add_runtime_dependency "more_core_extensions",    "~> 4.4"
-  s.add_runtime_dependency "nokogiri",                "~> 1.13", ">= 1.13.6"
+  s.add_runtime_dependency "nokogiri",                "~> 1.13", ">= 1.13.10"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"
   s.add_runtime_dependency "winrm",                   "~> 2.1"


### PR DESCRIPTION
@jrafanie or @bdunne Please review

The oparin branch specs are currently failing since it's locked and the security suite wants the latest version. See https://github.com/ManageIQ/manageiq/actions/runs/3688845022/jobs/6244115421#step:8:10

I'll have to bump the Gemfile.lock.release on oparin after this is backported