### PR TITLE
Update fog-openstack to v1.0

### DIFF
--- a/lib/gems/pending/util/object_storage/miq_swift_storage.rb
+++ b/lib/gems/pending/util/object_storage/miq_swift_storage.rb
@@ -95,7 +95,7 @@ class MiqSwiftStorage < MiqObjectStorage
   end
 
   #
-  # Some calls to Fog::Storage::OpenStack::Directories#get will
+  # Some calls to Fog::OpenStack::Storage::Directories#get will
   # return 'nil', and not return an error.  This would cause errors down the
   # line in '#upload' or '#download'.
   #
@@ -109,9 +109,10 @@ class MiqSwiftStorage < MiqObjectStorage
     @container ||= begin
                      container = swift.directories.get(container_name)
                      logger.debug("Swift container [#{container}] found") if container
-                     raise Fog::Storage::OpenStack::NotFound unless container
+                     raise Fog::OpenStack::Storage::NotFound unless container
+
                      container
-                   rescue Fog::Storage::OpenStack::NotFound
+                   rescue Fog::OpenStack::Storage::NotFound
                      if create_if_missing
                        logger.debug("Swift container #{container_name} does not exist.  Creating.")
                        create_container
@@ -152,7 +153,7 @@ class MiqSwiftStorage < MiqObjectStorage
       :connection_options          => { :debug_request => true }
     }
 
-    @swift = Fog::Storage::OpenStack.new(connection_params)
+    @swift = Fog::OpenStack::Storage.new(connection_params)
   end
 
   def create_container

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "awesome_spawn",           "~> 1.5"
   s.add_runtime_dependency "aws-sdk-s3",              "~> 1.0"
   s.add_runtime_dependency "bundler",                 "~> 2.1", ">= 2.1.4", "!= 2.2.10"
-  s.add_runtime_dependency "fog-openstack",           "~> 0.3"
+  s.add_runtime_dependency "fog-openstack",           "~> 1.0"
   s.add_runtime_dependency "more_core_extensions",    "~> 4.4"
   s.add_runtime_dependency "nokogiri",                "~> 1.14", ">= 1.14.3"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"


### PR DESCRIPTION
fog-openstack released v1.0 in Jan 2019 we should update to the latest version, this was also keeping us on an older version of fog-core

Co-depends:
* https://github.com/ManageIQ/manageiq-providers-openstack/pull/734