### PR TITLE
Ruby 3.1 - net/ftp was moved from stdlib to a gem

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -26,6 +26,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "bundler",                 "~> 2.1", ">= 2.1.4", "!= 2.2.10"
   s.add_runtime_dependency "fog-openstack",           "~> 1.0"
   s.add_runtime_dependency "more_core_extensions",    "~> 4.4"
+  s.add_runtime_dependency "net-ftp",                 "~> 0.1.2"
   s.add_runtime_dependency "nokogiri",                "~> 1.14", ">= 1.14.3"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"

--- a/spec/util/miq-hash_struct_spec.rb
+++ b/spec/util/miq-hash_struct_spec.rb
@@ -146,6 +146,13 @@ describe MiqHashStruct do
     let (:orig) { described_class.new("a" => 1, "b" => 2) }
 
     it("Marshal") { expect(Marshal.load(Marshal.dump(orig))).to eq(orig) }
-    it("YAML")    { expect(YAML.load(YAML.dump(orig))).to eq(orig) }
+    it("YAML") do
+      dump = YAML.dump(orig)
+      # Ruby 3.1 via psych 4.0 changed to default YAML.load to safe_load.
+      # Ruby 2.7 doesn't accept permitted_classes on load and doesn't respond to unsafe_load.
+      # Once 2.7 is dropped, we can safely use unsafe_load or load with a list of permitted_classes.
+      loaded = YAML.respond_to?(:unsafe_load) ? YAML.unsafe_load(dump) : YAML.load(dump)
+      expect(loaded).to eq(orig)
+    end
   end
 end


### PR DESCRIPTION
See: https://github.com/rails/rails/issues/45816
https://www.ruby-lang.org/en/news/2021/12/25/ruby-3-1-0-released/

Related: https://github.com/ManageIQ/manageiq/pull/22702
Part of: https://github.com/ManageIQ/manageiq/issues/22696