### PR TITLE
Fix stubbing of AwesomeSpawn private method results

### DIFF
--- a/spec/util/miq-system_spec.rb
+++ b/spec/util/miq-system_spec.rb
@@ -206,8 +206,10 @@ EOF
       ]
 
       stub_const("Sys::Platform::IMPL", :macosx)
-      expect(AwesomeSpawn).to receive(:launch).and_return([mac_df_output, "", 0])
-
+      expect(AwesomeSpawn)
+        .to receive(:run)
+        .with("df", {:params => ["-ki", "-l"]})
+        .and_return(AwesomeSpawn::CommandResult.new("abcd", mac_df_output, "", 123, 0))
       expect(described_class.disk_usage).to eq(expected)
     end
   end


### PR DESCRIPTION
This spec was stubbing an internal AwesomeSpawn method whose calling convention changed causing the spec to fail.

Changed the test to stub the external AwesomeSpawn interface instead which will be more stable across releases.

https://github.com/ManageIQ/awesome_spawn/pull/49/files#diff-d7c9ccd39e13a57416ff9b126be974738eab8e8f09451094d0e8108af465f1b8R81