### PR TITLE
Fix MiqXml handling of BOM + handle CVE-2024-39908

### DIFF
--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -279,15 +279,6 @@ module REXML
 
     def self.load(data)
       REXML::Document.new(data)
-    rescue => err
-      if err.class == ::Encoding::CompatibilityError
-        data_utf8 = data.dup.force_encoding('UTF-8')
-        # Check for UTF-8 BOM and remove
-        data_utf8 = data_utf8[3..-1] if data_utf8[0, 3] == "\xC3\xAF\xC2\xBB\xC2\xBF".force_encoding("UTF-8")
-        REXML::Document.new(data_utf8)
-      else
-        raise
-      end
     end
 
     def self.loadFile(filename)

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -28,6 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "more_core_extensions",    "~> 4.4"
   s.add_runtime_dependency "net-ftp",                 "~> 0.1.2"
   s.add_runtime_dependency "nokogiri",                "~> 1.14", ">= 1.14.3"
+  s.add_runtime_dependency "rexml",                   ">= 3.3.2"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"
   s.add_runtime_dependency "win32ole",                "~> 1.8.8" # this gem was extracted in ruby 3 - required if we use wmi on windows

--- a/spec/util/miq-xml_spec.rb
+++ b/spec/util/miq-xml_spec.rb
@@ -6,15 +6,34 @@ describe MiqXml do
     expect(xml.root.elements[1].attributes['attr1']).to eq(attr_string)
   end
 
-  it "handles loaded document with UTF-8 BOM" do
+  it "handles loaded document with top-level text nodes" do
     attr_string = "test string"
-    doc_text = "\xC3\xAF\xC2\xBB\xC2\xBF<test><element_1 attr1='#{attr_string}'/></test>"
+    doc_text = "XXX<test><element_1 attr1='#{attr_string}'/></test>"
+
     xml = MiqXml.load(doc_text)
     expect(xml.root.elements[1].attributes['attr1']).to eq(attr_string)
 
-    expect(xml.to_s[0, 3]).to eq("\xC3\xAF\xC2\xBB\xC2\xBF")
+    expect(xml.to_s).to start_with("XXX<test>")
+
     xml.write(xml_str = '', 1)
-    expect(xml_str[0, 3]).to eq("\xC3\xAF\xC2\xBB\xC2\xBF")
+    expect(xml_str).to start_with("\n<test>")
+  end
+
+  it "handles loaded document with UTF-8 BOM" do
+    bom = "\xEF\xBB\xBF".force_encoding("US-ASCII")
+    attr_string = "test string"
+    doc_text = "#{bom}<test><element_1 attr1='#{attr_string}'/></test>".force_encoding("US-ASCII")
+    expect(doc_text.bytes[0, 3]).to eq(bom.bytes)
+
+    xml = MiqXml.load(doc_text)
+    expect(xml.root.elements[1].attributes['attr1']).to eq(attr_string)
+
+    expect(xml.to_s.bytes[0, 3]).to_not eq(bom.bytes)
+    expect(xml.to_s).to start_with("<test><element_1")
+
+    xml.write(xml_str = '', 1)
+    expect(xml_str.bytes[0, 3]).to_not eq(bom.bytes)
+    expect(xml_str).to start_with("<test>\n <element_1")
   end
 
   it "add_element with control characters" do


### PR DESCRIPTION
The BOM handling code was incorrectly using `"\xC3\xAF\xC2\xBB\xC2\xBF"`, which is just `"ï»¿"` in UTF-8 encoding. The correct BOM marker is `"\xEF\xBB\xBF"` in binary encoding (which happens to be `"ï»¿"` when encoded as Windows-1252 encoding).

```ruby
> s = "\xC3\xAF\xC2\xBB\xC2\xBF" # UTF-8 encoded
=> "ï»¿"
> s.encode("WINDOWS-1252")
=> "\xEF\xBB\xBF"

> s = "\xEF\xBB\xBF" # UTF-8 encoded
=> "" # BOM is there but hidden in display
> s.force_encoding("WINDOWS-1252")
=> "\xEF\xBB\xBF"
```

I'm not sure why the original code used `"\xC3\xAF\xC2\xBB\xC2\xBF"`, but this code was originally written in 2012 in 9c26f1e4 around the Ruby 1.8/1.9 time frame and was added to handle various encoding problems with Ruby 1.9 (which is when Encoding was introduced).

There have been other commits such as 8209fb6e that have removed some of this older questionable code which should work in modern versions of REXML.

This commit adds some tests ensuring the correct BOM works as expected, and modifies the original BOM test to treat those leading characters more like top-level text nodes, which is how they were being interpreted in modern REXML anyway.

Note that in REXML 3.3.2, the `.write` method no longer prints out extraneous top-level text nodes. REXML 3.3.2 added an Exception for top-level text nodes _after_ the root node, but curiously did not raise an Exception for text nodes _before_ the root node. Nokogiri in STRICT mode will fail on both, so it's curious that REXML does not. Even so, I expect in the future REXML will fail on these leading text nodes, so we may have to revisit this at that time.

This commit also enforces the minimum version to REXML 3.3.2. This is partly because of CVE-2024-39908, and partly because it complicated the test code to support multiple versions of REXML.

@kbrock @jrafanie Please review.