### PR TITLE
Upgrade rexml to 3.3.3+ for CVE-2024-41123 and CVE-2024-41946

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -28,7 +28,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "more_core_extensions",    "~> 4.4"
   s.add_runtime_dependency "net-ftp",                 "~> 0.1.2"
   s.add_runtime_dependency "nokogiri",                "~> 1.14", ">= 1.14.3"
-  s.add_runtime_dependency "rexml",                   ">= 3.3.2"
+  s.add_runtime_dependency "rexml",                   ">= 3.3.4"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"
   s.add_runtime_dependency "win32ole",                "~> 1.8.8" # this gem was extracted in ruby 3 - required if we use wmi on windows

--- a/spec/util/miq-xml_spec.rb
+++ b/spec/util/miq-xml_spec.rb
@@ -6,19 +6,6 @@ describe MiqXml do
     expect(xml.root.elements[1].attributes['attr1']).to eq(attr_string)
   end
 
-  it "handles loaded document with top-level text nodes" do
-    attr_string = "test string"
-    doc_text = "XXX<test><element_1 attr1='#{attr_string}'/></test>"
-
-    xml = MiqXml.load(doc_text)
-    expect(xml.root.elements[1].attributes['attr1']).to eq(attr_string)
-
-    expect(xml.to_s).to start_with("XXX<test>")
-
-    xml.write(xml_str = '', 1)
-    expect(xml_str).to start_with("\n<test>")
-  end
-
   it "handles loaded document with UTF-8 BOM" do
     bom = "\xEF\xBB\xBF".force_encoding("US-ASCII")
     attr_string = "test string"


### PR DESCRIPTION
In #581 I wrote

> I expect in the future REXML will fail on these leading text nodes,
> so we may have to revisit this at that time.

and that has now happened in rexml 3.3.3 (https://github.com/ruby/rexml/pull/184), so this commit also removes the spec for leading text nodes, since they can no longer be parsed. The BOM test ensures that the leading BOM marker is not treated as a text node.

@jrafanie Please review.