### PR TITLE
Drop Rails 6.1 testing and add Rails 7.1 and 7.2 testing

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -15,8 +15,9 @@ jobs:
         - '3.0'
         - '3.1'
         rails-version:
-        - '6.1'
         - '7.0'
+        - '7.1'
+        - '7.2'
     env:
       CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
     steps:

--- a/Gemfile
+++ b/Gemfile
@@ -10,8 +10,10 @@ minimum_version =
   case ENV['TEST_RAILS_VERSION']
   when "7.0"
     "~>7.0.8"
-  else
-    "~>6.1.4"
+  when "7.1"
+    "~>7.1.4"
+  when "7.2"
+    "~>7.2.1"
   end
 
 gem "activesupport", minimum_version

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -37,7 +37,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ftpd",                      "~> 2.1.0"
   s.add_development_dependency "manageiq-style"
   s.add_development_dependency "rake",                      ">= 12.3.3"
-  s.add_development_dependency "rspec",                     "~> 3.5.0"
+  s.add_development_dependency "rspec",                     "~> 3.13"
   s.add_development_dependency "simplecov",                 ">= 0.21.2"
   s.add_development_dependency "timecop",                   "~> 0.9.1"
   s.add_development_dependency "xml-simple",                "~> 1.1.0"


### PR DESCRIPTION
@jrafanie @kbrock Please review.

The RSpec bump is because of https://github.com/rspec/rspec-mocks/issues/1530, which was released in rspec-mocks 3.12.4.  I bumped to 3.13 anyway since that's the latest and it still works.