### PR TITLE
Fix broken test matrix  and add ruby 3.2 and 3.3

### DIFF
--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -12,13 +12,18 @@ jobs:
     strategy:
       matrix:
         ruby-version:
-        - '3.0'
         - '3.1'
         rails-version:
         - '7.0'
         - '7.1'
         - '7.2'
+        include:
+        - ruby-version: '3.0'
+          rails-version: '7.0'
+        - ruby-version: '3.0'
+          rails-version: '7.1'
     env:
+      TEST_RAILS_VERSION: ${{ matrix.rails-version }}
       CC_TEST_REPORTER_ID: "${{ secrets.CC_TEST_REPORTER_ID }}"
     steps:
     - uses: actions/checkout@v4

--- a/.github/workflows/ci.yaml
+++ b/.github/workflows/ci.yaml
@@ -13,6 +13,8 @@ jobs:
       matrix:
         ruby-version:
         - '3.1'
+        - '3.2'
+        - '3.3'
         rails-version:
         - '7.0'
         - '7.1'


### PR DESCRIPTION
### TEST_RAILS_VERSION wasn't set in ENV so matrix was broken
Rails 7.2 will not install in versions of ruby less than 3.1.

Because we weren't setting the ENV variable properly, the test matrix
was not correctly testing against the correct rails version and passing.

### Add ruby 3.2 and 3.3 to the matrix
