### PR TITLE
[QUINTEROS] Fix rspec version used to match core's version

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -36,7 +36,7 @@ Gem::Specification.new do |s|
   s.add_development_dependency "ftpd",                      "~> 2.1.0"
   s.add_development_dependency "manageiq-style"
   s.add_development_dependency "rake",                      ">= 12.3.3"
-  s.add_development_dependency "rspec",                     "~> 3.5.0"
+  s.add_development_dependency "rspec",                     "~> 3.12.0"
   s.add_development_dependency "simplecov",                 ">= 0.21.2"
   s.add_development_dependency "timecop",                   "~> 0.9.1"
   s.add_development_dependency "xml-simple",                "~> 1.1.0"


### PR DESCRIPTION
~I expect tests to fail here because I need to backport the various rexml updates, however, this change is breaking rspec itself, and we can't get further without it.~

I tested the backport locally and it made everything go green, so I backported those rexml PRs first, and this is build on top.  I expect this to go green now.