### PR TITLE
Lockdown rexml to 3.4.2 at highest for now

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "more_core_extensions",    "~> 4.5"
   s.add_runtime_dependency "net-ftp",                 "~> 0.1.2"
   s.add_runtime_dependency "nokogiri",                "~> 1.14", ">= 1.14.3"
-  s.add_runtime_dependency "rexml",                   ">= 3.3.6"
+  s.add_runtime_dependency "rexml",                   ">= 3.3.6", "<= 3.4.2" # 3.4.3 raises a ParseException error 'No root element' with rexml documents created with empty strings, see: https://www.github.com/ruby/rexml/pull/291
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"
   s.add_runtime_dependency "win32ole",                "~> 1.8.8" # this gem was extracted in ruby 3 - required if we use wmi on windows

--- a/spec/util/xml/miq_rexml_spec.rb
+++ b/spec/util/xml/miq_rexml_spec.rb
@@ -149,6 +149,13 @@ describe MIQRexml do
       expect(xml_new.to_xml.to_s.tr("\"", "'").chomp).to eq("<?xml version='1.0' encoding='UTF-8'?>")
     end
 
+    it "load" do
+      xml_new_nil = MiqXml.load(nil, @xml_klass)
+      expect(xml_new_nil.root).to be_nil
+      xml_new_empty_string = MiqXml.load("", @xml_klass) # test broken by rexml 3.4.3
+      expect(xml_new_empty_string.root).to be_nil
+    end
+
     it "create new node" do
       node = MiqXml.newNode("scan_item", @xml_klass)
       expect(node.to_xml.to_s).to eq("<scan_item/>")


### PR DESCRIPTION
3.4.3 raises a ParseException error 'No root element' with rexml documents created with empty strings.

See: https://www.github.com/ruby/rexml/pull/291

We'll need to fix a few places where we do:
`REXML::Document.new("")`

and instead use:
`REXML::Document.new("<?xmlversion='1.0'?>")`

We also have places we do `REXML::Document.new(nil)` that might also need to be changed to avoid this breakage in 3.4.4 or later.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
