### PR TITLE
Upgrade REXML minumum to 3.4.4

### DIFF
--- a/lib/gems/pending/util/xml/miq_rexml.rb
+++ b/lib/gems/pending/util/xml/miq_rexml.rb
@@ -314,7 +314,7 @@ module REXML
 
     def self.decode(encodedText)
       return REXML::Document.new(MIQEncode.decode(encodedText)) if encodedText
-      REXML::Document.new("")
+      REXML::Document.new(nil)
     end
 
     def find_first(xpath, ns = nil)

--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -34,7 +34,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "more_core_extensions",    "~> 4.5"
   s.add_runtime_dependency "net-ftp",                 "~> 0.1.2"
   s.add_runtime_dependency "nokogiri",                "~> 1.14", ">= 1.14.3"
-  s.add_runtime_dependency "rexml",                   ">= 3.3.6", "<= 3.4.2" # 3.4.3 raises a ParseException error 'No root element' with rexml documents created with empty strings, see: https://www.github.com/ruby/rexml/pull/291
+  s.add_runtime_dependency "rexml",                   ">= 3.4.4"
   s.add_runtime_dependency "sys-proctable",           "~> 1.2.5"
   s.add_runtime_dependency "sys-uname",               "~> 1.2.1"
   s.add_runtime_dependency "win32ole",                "~> 1.8.8" # this gem was extracted in ruby 3 - required if we use wmi on windows

--- a/spec/util/xml/miq_rexml_spec.rb
+++ b/spec/util/xml/miq_rexml_spec.rb
@@ -149,11 +149,14 @@ describe MIQRexml do
       expect(xml_new.to_xml.to_s.tr("\"", "'").chomp).to eq("<?xml version='1.0' encoding='UTF-8'?>")
     end
 
-    it "load" do
+    it "#load creates new document with nil arg" do
       xml_new_nil = MiqXml.load(nil, @xml_klass)
       expect(xml_new_nil.root).to be_nil
-      xml_new_empty_string = MiqXml.load("", @xml_klass) # test broken by rexml 3.4.3
-      expect(xml_new_empty_string.root).to be_nil
+    end
+
+    it "#decode creates new document with nil arg" do
+      xml_new = REXML::Document.decode(nil)
+      expect(xml_new.root).to be_nil
     end
 
     it "create new node" do


### PR DESCRIPTION
Replaces https://github.com/ManageIQ/manageiq-gems-pending/pull/615


*    Bump rexml minimum

    3.4.2 addresses CVE-2025-58767
    3.4.4 addresses regression/backward compatibility broken in 3.4.3

    See also https://github.com/ManageIQ/manageiq-style/pull/65
    and https://www.github.com/ruby/rexml/issues/296

*    REXML suggests creating empty documents with nil argument

    See: https://github.com/ruby/rexml/blob/4ffe211b501614e769a8bf37d63a7037bb5d2e73/lib/rexml/document.rb#L49-L53