### PR TITLE
Cleanup mount ping

### DIFF
--- a/lib/gems/pending/util/mount/miq_generic_mount_session.rb
+++ b/lib/gems/pending/util/mount/miq_generic_mount_session.rb
@@ -90,22 +90,16 @@ class MiqGenericMountSession < MiqFileStorage::Interface
     @mnt_point = settings_mount_point || Dir.mktmpdir("miq_")
   end
 
-  def get_ping_depot_options
-    @@ping_depot_options ||= begin
-      opts = ::VMDB::Config.new("vmdb").config[:log][:collection] if defined?(::VMDB) && defined?(::VMDB::CONFIG)
-      opts = {:ping_depot => false}
-      opts
-    end
+  private def ping_depot_options
+    @ping_depot_options ||= {:ping_depot => false, :ping_depot_timeout => 20}
   end
 
   def ping_timeout
-    get_ping_depot_options
-    @@ping_timeout ||= (@@ping_depot_options[:ping_depot_timeout] || 20)
+    @ping_timeout ||= (ping_depot_options[:ping_depot_timeout] || 20)
   end
 
   def do_ping?
-    get_ping_depot_options
-    @@do_ping ||= @@ping_depot_options[:ping_depot] == true
+    @do_ping ||= ping_depot_options[:ping_depot] == true
   end
 
   def pingable?


### PR DESCRIPTION
- Removing Settings lookup which hasn't worked in ages. When then Settings were redesigned this code basically never ran anymore because ::VMDB::CONFIG was renamed to ::Vmdb::Config. Additionally, we've removed the log/collection/ping_* settings in the process of removing log collection.
- Removed use of class vars in favor of ivars
- Modernized ping_depot_options, and made it private

@jrafanie Please review.

Ultimately, I want to drop mount session stuff, but until PxeServer drops the need for it, it's has to stick around.

<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
