### PR TITLE
Allow bundler v4.0

### DIFF
--- a/manageiq-gems-pending.gemspec
+++ b/manageiq-gems-pending.gemspec
@@ -29,7 +29,7 @@ Gem::Specification.new do |s|
   s.add_runtime_dependency "activesupport",           ">=6.0"
   s.add_runtime_dependency "awesome_spawn",           "~> 1.5"
   s.add_runtime_dependency "aws-sdk-s3",              "~> 1.0"
-  s.add_runtime_dependency "bundler",                 "~> 2.1", ">= 2.1.4", "!= 2.2.10"
+  s.add_runtime_dependency "bundler",                 ">= 2.1.4", "!= 2.2.10"
   s.add_runtime_dependency "fog-openstack",           "~> 1.0"
   s.add_runtime_dependency "more_core_extensions",    "~> 4.5"
   s.add_runtime_dependency "net-ftp",                 "~> 0.1.2"


### PR DESCRIPTION
Allow newer bundler versions while still preventing `2.2.10`

TODO do we need a runtime dependency here at all?  Won't core's bundler dependency supersede this anyway?
<!--
1. Describe what this Pull Request does and why you think it is needed.
   If this PR includes UI or CLI changes, please include Before/After screenshots
   If this PR includes performance changes, please include Before/After metrics showing improvement.
-->

<!--
2. If this fixes an existing issue, please specify in `Fixes #<id>` format
   (As described in https://help.github.com/en/github/managing-your-work-on-github/linking-a-pull-request-to-an-issue)
-->

<!--
3. Ask @miq-bot to apply a scope label (bug, enhancement, etc) and any additional reviewers or assignees.
   (As described in https://github.com/ManageIQ/miq_bot#requested-tasks)
   e.g. `@miq-bot add-label label_name`
        `@miq-bot add-reviewer @name`
-->
