### PR TITLE
Set concurrent-ruby minimum to 1.3.7 for CVE-2026-54904

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,3 +17,6 @@ minimum_version =
   end
 
 gem "activesupport", minimum_version
+
+# security fixes for indirect dependencies
+gem "concurrent-ruby", ">=1.3.7" # CVE-2026-54904 https://github.com/ruby-concurrency/concurrent-ruby/security/advisories/GHSA-h8w8-99g7-qmvj


### PR DESCRIPTION
@agrare Please review.

Should close #650, #651, #652